### PR TITLE
Saving changed models fails with rails/activeresource master

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    shopify_api (3.2.3)
+    shopify_api (3.2.4)
       activeresource (>= 3.0.0)
-      pry
+      pry (>= 0.9.12.6)
       thor (~> 0.18.1)
 
 GEM
@@ -33,9 +33,9 @@ GEM
     mocha (0.14.0)
       metaclass (~> 0.0.1)
     multi_json (1.8.4)
-    pry (0.9.12.6)
-      coderay (~> 1.0)
-      method_source (~> 0.8)
+    pry (0.10.0)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
       slop (~> 3.4)
     rails-observers (0.1.2)
       activemodel (~> 4.0)


### PR DESCRIPTION
To reproduce:

```
#Gemfile:
gem 'activeresource', github: 'rails/activeresource', branch: 'master'
gem 'shopify_api', github: 'Shopify/shopify_api', branch: 'master'
```

```
p = ShopifyAPI::Product.find(_existing_product_id_)
p.title = p.title + " changed"
p.save

=>
PUT https://tees-dev.myshopify.com:443/admin/products/288628431.json
INFO -- : --> 400 Bad Request 62 (328.0ms)
INFO -- : Request:
{}
INFO -- : Headers: {"Content-Type"=>"application/json", "X-Shopify-Access-Token"=>"xxxx"}
INFO -- : Response:
{"errors":{"product":"Required parameter missing or invalid"}}
ActiveResource::BadRequest: Failed.  Response code = 400.  Response message = Bad Request.
from bundler/gems/activeresource-23786e2ff935/lib/active_resource/connection.rb:138:in `handle_response'
```

The problem is in the overridden `ActiveResource::Base#encode` method.
