### PR TITLE
[WIP] Use newly created abandoned checkouts route from core

### DIFF
--- a/lib/shopify_api/resources/abandoned_checkout.rb
+++ b/lib/shopify_api/resources/abandoned_checkout.rb
@@ -2,6 +2,5 @@
 
 module ShopifyAPI
   class AbandonedCheckout < Base
-    self.element_name = "checkout"
   end
 end

--- a/test/abandoned_checkouts_test.rb
+++ b/test/abandoned_checkouts_test.rb
@@ -10,7 +10,7 @@ class AbandonedCheckoutsTest < Test::Unit::TestCase
   end
 
   test ":create creates a checkout" do
-    fake 'checkouts', method: :post, status: 201, body: load_fixture('abandoned_checkout')
+    fake 'abandoned_checkouts', method: :post, status: 201, body: load_fixture('abandoned_checkout')
 
     checkout = ShopifyAPI::AbandonedCheckout.create
 
@@ -19,7 +19,7 @@ class AbandonedCheckoutsTest < Test::Unit::TestCase
   end
 
   test "get all checkouts indexed by token" do
-    fake 'checkouts', method: :get, status: 200, body: load_fixture('abandoned_checkouts')
+    fake 'abandoned_checkouts', method: :get, status: 200, body: load_fixture('abandoned_checkouts')
 
     checkouts = ShopifyAPI::AbandonedCheckout.all
 


### PR DESCRIPTION
The `admin/abandoned_checkouts` route is now available on core.
Hence, there is no need to specify the `element_name`, as we can use the default one.

Depends on https://github.com/Shopify/shopify/pull/198172 .