### PR TITLE
Call Session#request_token with indifferent hash keys

### DIFF
--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -72,6 +72,18 @@ class SessionTest < Test::Unit::TestCase
     end
   end
 
+  test "Indifferent params access" do
+    api_version = ShopifyAPI::ApiVersion.new(handle: :unstable)
+    fake nil,
+      url: "https://testshop.myshopify.com/admin/oauth/access_token",
+      method: :post,
+      body: '{"access_token":"any-token" }'
+    session = ShopifyAPI::Session.new(domain: "testshop.myshopify.com", token: nil, api_version: api_version)
+
+    params = { "code" => 'any-code', 'timestamp' => Time.new }
+    assert session.request_token(params.merge(hmac: generate_signature(params)))
+  end
+
   test "setup api_key and secret for all sessions" do
     ShopifyAPI::Session.setup(:api_key => "My test key", :secret => "My test secret")
     assert_equal "My test key", ShopifyAPI::Session.api_key


### PR DESCRIPTION
My auth request is a hash where the keys are strings rather than symbols. The `Session#request_token` did not like. In other words, this failed
```
token = session.request_token({:code=>"e3c4", :hmac=>"5ad0", :shop=>"shop1", "timestamp" =>1574273231})
```
Using `HashWithIndifferentAccess` allowed me to have mixed key types (for better or worse). In the hash below, one key clobbers the other. This seems to be acceptable behaviour for the hmac check
``` 
>> h = {"key" => 1, key: 2}
=> {"key"=>1, :key=>2}
>> h = {"key" => 1, key: 2}.with_indifferent_access
=> {"key"=>2}
```

Here is a before/after of the projects tests.

Before code change
```
$ rake test
Run options: --seed 51380

# Running:

...........................................................................................................................................................................................................................................................E........................................................

Finished in 1.985446s, 155.1289 runs/s, 261.9059 assertions/s.

  1) Error:
SessionTest#test_Indifferent params access:
ShopifyAPI::ValidationException: Invalid timestamp: Possible malicious login
    /Users/rcapozzi/src/github.com/rcapozzi-shopify/shopify_api/lib/shopify_api/session.rb:104:in `request_token'
    /Users/rcapozzi/src/github.com/rcapozzi-shopify/shopify_api/test/session_test.rb:84:in `block in <class:SessionTest>'

308 runs, 520 assertions, 0 failures, 1 errors, 0 skips
rake aborted!
Command failed with status (1)
/usr/local/lib/ruby/gems/2.6.0/gems/rake-13.0.1/exe/rake:27:in `<top (required)>'
Tasks: TOP => test
(See full trace by running task with --trace)
```
After code change

```
rcapozzi@Raymonds-MacBook-Pro shopify_api
$ rake test
Run options: --seed 41280

# Running:

....................................................................................................................................................................................................................................................................................................................

Finished in 1.933314s, 159.3119 runs/s, 269.4855 assertions/s.

308 runs, 521 assertions, 0 failures, 0 errors, 0 skips
```
