### PR TITLE
Removed deprecated field from collect fixture

### DIFF
--- a/test/fixtures/collect.json
+++ b/test/fixtures/collect.json
@@ -3,7 +3,6 @@
     "id": 841564295,
     "collection_id": 841564295,
     "product_id": 632910392,
-    "featured": false,
     "created_at": null,
     "updated_at": null,
     "position": 1,


### PR DESCRIPTION
As of April 1st 2020 the `featured` attribute is not a supported
`collect` property anymore.

Compare [Collect API 2019-04](https://help.shopify.com/en/api/reference/products/collect?api[version]=2019-04) with [Collect API 2020-01](https://help.shopify.com/en/api/reference/products/collect?api[version]=2020-01)

In order to keep the fixtures in line with the api properties the
deprecated attribute has been removed.