### PR TITLE
Add bulk operation utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,26 @@ jsonl.each_line do |line|
 end
 ```
 
+Take note that nested connections are listed on their own line in the file and although guaranteed to follow the parent resource in order, it's not a guarantee it will located directly after that resource. A trick is to read the file in reverse, so that any children nodes are tracked before the parent node is discovered. You can use the `BulkOperationUtil` class to parse and output nodes along with their children nested within each node:
+```
+url = "https://storage.googleapis.com/shopify/k524jdq...json"
+
+# Only output parent nodes with nested connections, in reverse order
+ShopifyAPI::BulkOperationUtil.with_nested_connections(url) do |node|
+  # A `__children` property is added to the parsed result, which will contain
+  # any child nodes that reference the node from "__parentId"
+  puts node["__children"]
+end
+```
+
+Using the JSON example above, this parses an output as such:
+```
+{"id"=>"gid://shopify/Product/1921569357880", "__children"=>[{"id"=>"gid://shopify/ProductVariant/19435459117112", "title"=>"47"}]}
+...
+{"id"=>"gid://shopify/Product/1921569226808", "__children"=>[{"id"=>"gid://shopify/ProductVariant/19435458986123", "title"=>"52"},
+                                                             {"id"=>"gid://shopify/ProductVariant/19435458986040", "title"=>"70"}]}
+```
+
 ## Pagination
 
 Shopify uses [Relative cursor-based pagination](https://shopify.dev/tutorials/make-paginated-requests-to-rest-admin-api) to provide more than a single page of results. 

--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ end
 ```
 
 Take note that nested connections are listed on their own line in the file and although guaranteed to follow the parent resource in order, it's not a guarantee it will located directly after that resource. A trick is to read the file in reverse, so that any children nodes are tracked before the parent node is discovered. You can use the `BulkOperationUtil` class to parse and output nodes along with their children nested within each node:
-```
+```ruby
 url = "https://storage.googleapis.com/shopify/k524jdq...json"
 
 # Only output parent nodes with nested connections, in reverse order
@@ -474,7 +474,7 @@ end
 ```
 
 Using the JSON example above, this parses an output as such:
-```
+```ruby
 {"id"=>"gid://shopify/Product/1921569357880", "__children"=>[{"id"=>"gid://shopify/ProductVariant/19435459117112", "title"=>"47"}]}
 ...
 {"id"=>"gid://shopify/Product/1921569226808", "__children"=>[{"id"=>"gid://shopify/ProductVariant/19435458986123", "title"=>"52"},

--- a/README.md
+++ b/README.md
@@ -466,10 +466,17 @@ Take note that nested connections are listed on their own line in the file and a
 url = "https://storage.googleapis.com/shopify/k524jdq...json"
 
 # Only output parent nodes with nested connections, in reverse order
-ShopifyAPI::BulkOperationUtil.open_with_nested_connections(url) do |node|
+ShopifyAPI::BulkOperationUtil.open_with_nested_connections(url) do |node, index|
   # A `__children` property is added to the parsed result, which will contain
   # any child nodes that reference the node from "__parentId"
   puts node["__children"]
+
+  # Note: since this parses the data in reverse, the index will also be reversed,
+  # and not correlate one-to-one per line, but rather per parent resource (i.e. 
+  # the last line will be index 0 and work forward toward the beginning).
+  # In most cases, the order of the line number isn't significant, but helpful to
+  # track which nodes you've processed.
+  puts "Index: #{index}"
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ Take note that nested connections are listed on their own line in the file and a
 url = "https://storage.googleapis.com/shopify/k524jdq...json"
 
 # Only output parent nodes with nested connections, in reverse order
-ShopifyAPI::BulkOperationUtil.with_nested_connections(url) do |node|
+ShopifyAPI::BulkOperationUtil.open_with_nested_connections(url) do |node|
   # A `__children` property is added to the parsed result, which will contain
   # any child nodes that reference the node from "__parentId"
   puts node["__children"]

--- a/lib/shopify_api.rb
+++ b/lib/shopify_api.rb
@@ -25,6 +25,7 @@ require 'shopify_api/connection'
 require 'shopify_api/pagination_link_headers'
 require 'shopify_api/graphql'
 require 'shopify_api/graphql/railtie' if defined?(Rails)
+require 'shopify_api/bulk_operation_util'
 
 if ShopifyAPI::Base.respond_to?(:connection_class)
   ShopifyAPI::Base.connection_class = ShopifyAPI::Connection

--- a/lib/shopify_api/bulk_operation_util.rb
+++ b/lib/shopify_api/bulk_operation_util.rb
@@ -10,7 +10,7 @@ module ShopifyAPI
       # bulk operations output nested connections as new lines in the file, we
       # must loop through each line and connect these resources. This will read
       # the file in reverse so that any child nodes will be listed first.
-      def with_nested_connections(url)
+      def open_with_nested_connections(url)
         # Keep a list of nodes that will collect child nodes
         parent_nodes = {}
 

--- a/lib/shopify_api/bulk_operation_util.rb
+++ b/lib/shopify_api/bulk_operation_util.rb
@@ -17,7 +17,7 @@ module ShopifyAPI
         # Open the file using OpenURI, this will save a temp file and will be
         # read one line at a time for memory efficiency.
         URI.parse(url).open do |file|
-          file.reverse_each do |line|
+          file.reverse_each.with_index do |line, index|
             next if line.blank?
 
             begin
@@ -32,7 +32,7 @@ module ShopifyAPI
             else
               node["__children"] = parent_nodes.delete(node["id"]) || []
 
-              yield(node)
+              yield(node, index)
             end
           end
         end

--- a/lib/shopify_api/bulk_operation_util.rb
+++ b/lib/shopify_api/bulk_operation_util.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+require 'open-uri'
+
+module ShopifyAPI
+  # Helpful methods when dealing with bulk operations.
+  class BulkOperationUtil
+    class << self
+      # A memory effective way to read nodes from a bulk operation URL. Since
+      # bulk operations output nested connections as new lines in the file, we
+      # must loop through each line and connect these resources. This will read
+      # the file in reverse so that any child nodes will be listed first.
+      def with_nested_connections(url)
+        # Keep a list of nodes that will collect child nodes
+        parent_nodes = {}
+
+        # Open the file using OpenURI, this will save a temp file and will be
+        # read one line at a time for memory efficiency.
+        open(url) do |file|
+          file.reverse_each do |line|
+            next if line.blank?
+
+            node = JSON.parse(line)
+
+            if (parent_id = node["__parentId"])
+              (parent_nodes[parent_id] ||= []) << node.except("__parentId")
+            else
+              node["__children"] = parent_nodes.delete(node["id"]) || []
+
+              yield(node)
+            end
+          rescue JSON::ParserError => e
+            raise JSON::ParserError, "Failed to parse bulk operation line " \
+                                     "'#{line.truncate(150)}': #{e.message}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/shopify_api/bulk_operation_util.rb
+++ b/lib/shopify_api/bulk_operation_util.rb
@@ -15,7 +15,7 @@ module ShopifyAPI
 
         # Open the file using OpenURI, this will save a temp file and will be
         # read one line at a time for memory efficiency.
-        open(url) do |file|
+        URI.open(url) do |file|
           file.reverse_each do |line|
             next if line.blank?
 

--- a/lib/shopify_api/version.rb
+++ b/lib/shopify_api/version.rb
@@ -1,3 +1,3 @@
 module ShopifyAPI
-  VERSION = "9.1.1"
+  VERSION = "9.1.2"
 end

--- a/test/bulk_operation_util_test.rb
+++ b/test/bulk_operation_util_test.rb
@@ -20,7 +20,7 @@ class BulkOperationUtilTest < Test::Unit::TestCase
 
     nodes = []
 
-    ShopifyAPI::BulkOperationUtil.with_nested_connections(url) do |node|
+    ShopifyAPI::BulkOperationUtil.open_with_nested_connections(url) do |node|
       nodes << node
     end
 
@@ -49,7 +49,7 @@ class BulkOperationUtilTest < Test::Unit::TestCase
 
     nodes = []
 
-    ShopifyAPI::BulkOperationUtil.with_nested_connections(url) do |node|
+    ShopifyAPI::BulkOperationUtil.open_with_nested_connections(url) do |node|
       nodes << node
     end
 
@@ -77,7 +77,7 @@ class BulkOperationUtilTest < Test::Unit::TestCase
 
     nodes = []
 
-    ShopifyAPI::BulkOperationUtil.with_nested_connections(url) do |node|
+    ShopifyAPI::BulkOperationUtil.open_with_nested_connections(url) do |node|
       nodes << node
     end
 
@@ -102,7 +102,7 @@ class BulkOperationUtilTest < Test::Unit::TestCase
     stub_request(:get, url).to_return(body: data)
 
     assert_raises(JSON::ParserError) do
-      ShopifyAPI::BulkOperationUtil.with_nested_connections(url) {}
+      ShopifyAPI::BulkOperationUtil.open_with_nested_connections(url) {}
     end
   end
 
@@ -120,7 +120,7 @@ class BulkOperationUtilTest < Test::Unit::TestCase
     stub_request(:get, url).to_return(body: response_body, status: 400)
 
     assert_raises(OpenURI::HTTPError) do
-      ShopifyAPI::BulkOperationUtil.with_nested_connections(url) {}
+      ShopifyAPI::BulkOperationUtil.open_with_nested_connections(url) {}
     end
   end
 end

--- a/test/bulk_operation_util_test.rb
+++ b/test/bulk_operation_util_test.rb
@@ -1,0 +1,126 @@
+require 'test_helper'
+
+class BulkOperationUtilTest < Test::Unit::TestCase
+  def test_with_nested_children_connections_mixed_ordered
+    url = "https://example.myshopify.com/files/products.json"
+
+    data = <<~JSON
+      {"id":"gid://shopify/Product/1921569651651"}
+      {"id":"gid://shopify/Product/1921569226808"}
+      {"id":"gid://shopify/ProductVariant/194354589324927","title":"66","__parentId":"gid://shopify/Product/1921569226808"}
+      {"id":"gid://shopify/ProductVariant/19435458986040","title":"70","__parentId":"gid://shopify/Product/1921569226808"}
+      {"id":"gid://shopify/Product/1921569325112"}
+      {"id":"gid://shopify/ProductVariant/19435459084344","title":"36","__parentId":"gid://shopify/Product/1921569325112"}
+      {"id":"gid://shopify/Product/1921569357880"}
+      {"id":"gid://shopify/ProductVariant/19435459117112","title":"47","__parentId":"gid://shopify/Product/1921569357880"}
+      {"id":"gid://shopify/ProductVariant/19435458986123","title":"52","__parentId":"gid://shopify/Product/1921569226808"}
+    JSON
+
+    stub_request(:get, url).to_return(body: data)
+
+    nodes = []
+
+    ShopifyAPI::BulkOperationUtil.with_nested_connections(url) do |node|
+      nodes << node
+    end
+
+    expected_results = [
+      {"id"=>"gid://shopify/Product/1921569357880", "__children"=>[{"id"=>"gid://shopify/ProductVariant/19435459117112", "title"=>"47"}]},
+      {"id"=>"gid://shopify/Product/1921569325112", "__children"=>[{"id"=>"gid://shopify/ProductVariant/19435459084344", "title"=>"36"}]},
+      {"id"=>"gid://shopify/Product/1921569226808", "__children"=>[{"id"=>"gid://shopify/ProductVariant/19435458986123", "title"=>"52"}, {"id"=>"gid://shopify/ProductVariant/19435458986040", "title"=>"70"}, {"id"=>"gid://shopify/ProductVariant/194354589324927", "title"=>"66"}]},
+      {"id"=>"gid://shopify/Product/1921569651651", "__children"=>[]}
+    ]
+
+    assert_equal expected_results, nodes
+  end
+
+  def test_with_nested_children_connections_ordered
+    url = "https://example.myshopify.com/files/products.json"
+
+    data = <<~JSON
+      {"id":"gid://shopify/Product/1921569226808"}
+      {"id":"gid://shopify/ProductVariant/194354589324927","title":"66","__parentId":"gid://shopify/Product/1921569226808"}
+      {"id":"gid://shopify/ProductVariant/19435458986123","title":"52","__parentId":"gid://shopify/Product/1921569226808"}
+      {"id":"gid://shopify/Product/1921569325112"}
+      {"id":"gid://shopify/ProductVariant/19435459084344","title":"36","__parentId":"gid://shopify/Product/1921569325112"}
+    JSON
+
+    stub_request(:get, url).to_return(body: data)
+
+    nodes = []
+
+    ShopifyAPI::BulkOperationUtil.with_nested_connections(url) do |node|
+      nodes << node
+    end
+
+    expected_results = [
+      {"id"=>"gid://shopify/Product/1921569325112", "__children"=>[{"id"=>"gid://shopify/ProductVariant/19435459084344", "title"=>"36"}]},
+      {"id"=>"gid://shopify/Product/1921569226808", "__children"=>[{"id"=>"gid://shopify/ProductVariant/19435458986123", "title"=>"52"}, {"id"=>"gid://shopify/ProductVariant/194354589324927", "title"=>"66"}]},
+    ]
+
+    assert_equal expected_results, nodes
+  end
+
+  def test_with_nested_children_connections_unordered
+    url = "https://example.myshopify.com/files/products.json"
+
+    data = <<~JSON
+      {"id":"gid://shopify/Product/1921569226808"}
+      {"id":"gid://shopify/Product/1921569325112"}
+      {"id":"gid://shopify/Product/1921569325342"}
+      {"id":"gid://shopify/ProductVariant/194354589324927","title":"66","__parentId":"gid://shopify/Product/1921569226808"}
+      {"id":"gid://shopify/ProductVariant/19435459084502","title":"99","__parentId":"gid://shopify/Product/1921569325342"}
+      {"id":"gid://shopify/ProductVariant/19435459084344","title":"36","__parentId":"gid://shopify/Product/1921569325112"}
+    JSON
+
+    stub_request(:get, url).to_return(body: data)
+
+    nodes = []
+
+    ShopifyAPI::BulkOperationUtil.with_nested_connections(url) do |node|
+      nodes << node
+    end
+
+    expected_results = [
+      {"id"=>"gid://shopify/Product/1921569325342", "__children"=>[{"id"=>"gid://shopify/ProductVariant/19435459084502", "title"=>"99"}]},
+      {"id"=>"gid://shopify/Product/1921569325112", "__children"=>[{"id"=>"gid://shopify/ProductVariant/19435459084344", "title"=>"36"}]},
+      {"id"=>"gid://shopify/Product/1921569226808", "__children"=>[{"id"=>"gid://shopify/ProductVariant/194354589324927", "title"=>"66"}]},
+    ]
+
+    assert_equal expected_results, nodes
+  end
+
+  def test_with_raises_error_with_bad_json
+    url = "https://example.myshopify.com/sneaky.json"
+
+    data = <<~JSON
+      {"id":"gid://shopify/Product/1921569651651"}
+      {id: gid://shopify/ProductVariant/19435458986342}
+      {"id":"gid://shopify/ProductVariant/19435458986123","title":"52","__parentId":"gid://shopify/Product/1921569226808"}
+    JSON
+
+    stub_request(:get, url).to_return(body: data)
+
+    assert_raises(JSON::ParserError) do
+      ShopifyAPI::BulkOperationUtil.with_nested_connections(url) {}
+    end
+  end
+
+  def test_with_raises_error_with_bad_request
+    url = "https://example.myshopify.com/customers.json"
+
+    response_body = <<~XML
+      <?xml version='1.0' encoding='UTF-8'?>
+      <Error><Code>ExpiredToken</Code>
+      <Message>The provided token has expired.</Message>
+      <Details>Request signature expired at: 1970-01-01T00:26:29+00:00</Details>
+      </Error>
+    XML
+
+    stub_request(:get, url).to_return(body: response_body, status: 400)
+
+    assert_raises(OpenURI::HTTPError) do
+      ShopifyAPI::BulkOperationUtil.with_nested_connections(url) {}
+    end
+  end
+end


### PR DESCRIPTION
This pull request adds a utility for parsing bulk requests with nested connections inline with the parent object.

See `tests/bulk_operation_util_test.rb` for examples.

See issue #729 for more information.

Updated Readme and bumped version number