### PR TITLE
Make ApiVersion::NullVersion Comparable

### DIFF
--- a/lib/shopify_api/api_version.rb
+++ b/lib/shopify_api/api_version.rb
@@ -200,6 +200,9 @@ module ShopifyAPI
         alias_method :verified, :raise_not_set_error
         alias_method :latest_supported, :raise_not_set_error
         alias_method :name, :raise_not_set_error
+        alias_method :<, :raise_not_set_error
+        alias_method :>, :raise_not_set_error
+        alias_method :<=>, :raise_not_set_error
       end
     end
   end

--- a/lib/shopify_api/api_version.rb
+++ b/lib/shopify_api/api_version.rb
@@ -176,6 +176,8 @@ module ShopifyAPI
 
     class NullVersion
       class << self
+        include Comparable
+
         def new(*_args)
           raise NoMethodError, "NullVersion is an abstract class and cannot be instantiated."
         end
@@ -200,8 +202,6 @@ module ShopifyAPI
         alias_method :verified, :raise_not_set_error
         alias_method :latest_supported, :raise_not_set_error
         alias_method :name, :raise_not_set_error
-        alias_method :<, :raise_not_set_error
-        alias_method :>, :raise_not_set_error
         alias_method :<=>, :raise_not_set_error
       end
     end

--- a/test/api_version_test.rb
+++ b/test/api_version_test.rb
@@ -132,6 +132,18 @@ class ApiVersionTest < Test::Unit::TestCase
     assert_raises(ShopifyAPI::ApiVersion::ApiVersionNotSetError) do
       ShopifyAPI::ApiVersion::NullVersion.stable?
     end
+
+    assert_raises(ShopifyAPI::ApiVersion::ApiVersionNotSetError) do
+      ShopifyAPI::ApiVersion::NullVersion < ShopifyAPI::ApiVersion.find_version('2020-01')
+    end
+
+    assert_raises(ShopifyAPI::ApiVersion::ApiVersionNotSetError) do
+      ShopifyAPI::ApiVersion::NullVersion > ShopifyAPI::ApiVersion.find_version('2020-01')
+    end
+
+    assert_raises(ShopifyAPI::ApiVersion::ApiVersionNotSetError) do
+      ShopifyAPI::ApiVersion::NullVersion <=> ShopifyAPI::ApiVersion.find_version('2020-01')
+    end
   end
 
   test "NullVersion cannot be instantiated and raises NoMethodError if attempted" do


### PR DESCRIPTION
# Problem Statement
`ApiVersion::NullVersion` can be compared with an instance of `ApiVersion` which can cause a `TypeError: compared with non class/module` error. For example: https://github.com/Shopify/shopify_api/blob/master/lib/shopify_api/resources/product.rb#L55

The purpose of this PR is to provide a more meaningful exception when `ApiVersion::NullVersion` is used as a comparable.

# Solution
Include `Comparable` statically and alias the spaceship operator to `raise_not_set_error`