### PR TITLE
Validate HMAC using both old and new API secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Note: For changes to the API, see https://shopify.dev/changelog?filter=api
 
 ## Unreleased
 
+- [#990](https://github.com/Shopify/shopify_api/pull/990) Validate `hmac` signature of OAuth callback using both old and new API secrets
+
 ## Version 11.0.0
 
 - [#987](https://github.com/Shopify/shopify_api/pull/987) ⚠️ [Breaking] Add REST resources for July 2022 API version, remove support and REST resources for July 2021 (`2021-07`) API version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Note: For changes to the API, see https://shopify.dev/changelog?filter=api
 
 ## Unreleased
 
-- [#990](https://github.com/Shopify/shopify_api/pull/990) Validate `hmac` signature of OAuth callback using both old and new API secrets
+- [#990](https://github.com/Shopify/shopify-api-ruby/pull/991) Validate `hmac` signature of OAuth callback using both old and new API secrets
 
 ## Version 11.0.0
 

--- a/lib/shopify_api/utils/hmac_validator.rb
+++ b/lib/shopify_api/utils/hmac_validator.rb
@@ -13,18 +13,28 @@ module ShopifyAPI
         def validate(verifiable_query)
           return false unless verifiable_query.hmac
 
-          received_signature = verifiable_query.hmac
-          computed_signature = compute_signature(verifiable_query.to_signable_string)
-          OpenSSL.secure_compare(computed_signature, received_signature)
+          result = validate_signature(verifiable_query, Context.api_secret_key)
+          if result || Context.old_api_secret_key.blank?
+            result
+          else
+            validate_signature(verifiable_query, T.must(Context.old_api_secret_key))
+          end
         end
 
         private
 
-        sig { params(signable_string: String).returns(String) }
-        def compute_signature(signable_string)
+        sig { params(verifiable_query: VerifiableQuery, secret: String).returns(T::Boolean) }
+        def validate_signature(verifiable_query, secret)
+          received_signature = verifiable_query.hmac
+          computed_signature = compute_signature(verifiable_query.to_signable_string, secret)
+          OpenSSL.secure_compare(computed_signature, received_signature)
+        end
+
+        sig { params(signable_string: String, secret: String).returns(String) }
+        def compute_signature(signable_string, secret)
           OpenSSL::HMAC.hexdigest(
             OpenSSL::Digest.new("sha256"),
-            ShopifyAPI::Context.api_secret_key,
+            secret,
             signable_string,
           )
         end

--- a/test/utils/hmac_validator_test.rb
+++ b/test/utils/hmac_validator_test.rb
@@ -6,47 +6,10 @@ require_relative "../test_helper"
 module ShopifyAPITest
   module Utils
     class HmacValidatorTest < Test::Unit::TestCase
-      def test_invalid_signature
-        auth_query = ShopifyAPI::Auth::Oauth::AuthQuery.new(
-          code: query[:code],
-          shop: query[:shop],
-          timestamp: query[:timestamp],
-          state: query[:state],
-          host: query[:host],
-          hmac: "invalid"
-        )
-        refute(ShopifyAPI::Utils::HmacValidator.validate(auth_query))
-      end
+      def setup
+        super
 
-      def test_valid_signature
-        auth_query = ShopifyAPI::Auth::Oauth::AuthQuery.new(
-          code: query[:code],
-          shop: query[:shop],
-          timestamp: query[:timestamp],
-          state: query[:state],
-          host: query[:host],
-          hmac: hmac(query, ShopifyAPI::Context.api_secret_key)
-        )
-        assert(ShopifyAPI::Utils::HmacValidator.validate(auth_query))
-      end
-
-      def test_valid_signature_signed_with_old_api_secret_key
-        modify_context(old_api_secret_key: "OLD_API_SECRET_KEY")
-        auth_query = ShopifyAPI::Auth::Oauth::AuthQuery.new(
-          code: query[:code],
-          shop: query[:shop],
-          timestamp: query[:timestamp],
-          state: query[:state],
-          host: query[:host],
-          hmac: hmac(query, ShopifyAPI::Context.old_api_secret_key)
-        )
-        assert(ShopifyAPI::Utils::HmacValidator.validate(auth_query))
-      end
-
-      private
-
-      def query
-        {
+        @query = {
           code: "somecode",
           host: "host",
           shop: "some-shop.myshopify.com",
@@ -54,6 +17,45 @@ module ShopifyAPITest
           timestamp: "123456",
         }
       end
+
+      def test_invalid_signature
+        auth_query = ShopifyAPI::Auth::Oauth::AuthQuery.new(
+          code: @query[:code],
+          shop: @query[:shop],
+          timestamp: @query[:timestamp],
+          state: @query[:state],
+          host: @query[:host],
+          hmac: "invalid"
+        )
+        refute(ShopifyAPI::Utils::HmacValidator.validate(auth_query))
+      end
+
+      def test_valid_signature
+        auth_query = ShopifyAPI::Auth::Oauth::AuthQuery.new(
+          code: @query[:code],
+          shop: @query[:shop],
+          timestamp: @query[:timestamp],
+          state: @query[:state],
+          host: @query[:host],
+          hmac: hmac(@query, ShopifyAPI::Context.api_secret_key)
+        )
+        assert(ShopifyAPI::Utils::HmacValidator.validate(auth_query))
+      end
+
+      def test_valid_signature_signed_with_old_api_secret_key
+        modify_context(old_api_secret_key: "OLD_API_SECRET_KEY")
+        auth_query = ShopifyAPI::Auth::Oauth::AuthQuery.new(
+          code: @query[:code],
+          shop: @query[:shop],
+          timestamp: @query[:timestamp],
+          state: @query[:state],
+          host: @query[:host],
+          hmac: hmac(@query, ShopifyAPI::Context.old_api_secret_key)
+        )
+        assert(ShopifyAPI::Utils::HmacValidator.validate(auth_query))
+      end
+
+      private
 
       def hmac(query_to_sign, secret)
         OpenSSL::HMAC.hexdigest(

--- a/test/utils/hmac_validator_test.rb
+++ b/test/utils/hmac_validator_test.rb
@@ -7,39 +7,60 @@ module ShopifyAPITest
   module Utils
     class HmacValidatorTest < Test::Unit::TestCase
       def test_invalid_signature
-        query = ShopifyAPI::Auth::Oauth::AuthQuery.new(
-          code: "somecode",
-          shop: "some-shop.myshopify.com",
-          state: "1234",
-          timestamp: "123456",
-          hmac: "invalid",
-          host: "host"
+        auth_query = ShopifyAPI::Auth::Oauth::AuthQuery.new(
+          code: query[:code],
+          shop: query[:shop],
+          timestamp: query[:timestamp],
+          state: query[:state],
+          host: query[:host],
+          hmac: "invalid"
         )
-        refute(ShopifyAPI::Utils::HmacValidator.validate(query))
+        refute(ShopifyAPI::Utils::HmacValidator.validate(auth_query))
       end
 
       def test_valid_signature
-        query_to_sign = {
+        auth_query = ShopifyAPI::Auth::Oauth::AuthQuery.new(
+          code: query[:code],
+          shop: query[:shop],
+          timestamp: query[:timestamp],
+          state: query[:state],
+          host: query[:host],
+          hmac: hmac(query, ShopifyAPI::Context.api_secret_key)
+        )
+        assert(ShopifyAPI::Utils::HmacValidator.validate(auth_query))
+      end
+
+      def test_valid_signature_signed_with_old_api_secret_key
+        modify_context(old_api_secret_key: "OLD_API_SECRET_KEY")
+        auth_query = ShopifyAPI::Auth::Oauth::AuthQuery.new(
+          code: query[:code],
+          shop: query[:shop],
+          timestamp: query[:timestamp],
+          state: query[:state],
+          host: query[:host],
+          hmac: hmac(query, ShopifyAPI::Context.old_api_secret_key)
+        )
+        assert(ShopifyAPI::Utils::HmacValidator.validate(auth_query))
+      end
+
+      private
+
+      def query
+        {
           code: "somecode",
           host: "host",
           shop: "some-shop.myshopify.com",
           state: "1234",
           timestamp: "123456",
         }
-        hmac = OpenSSL::HMAC.hexdigest(
+      end
+
+      def hmac(query_to_sign, secret)
+        OpenSSL::HMAC.hexdigest(
           OpenSSL::Digest.new("sha256"),
-          ShopifyAPI::Context.api_secret_key,
+          secret,
           URI.encode_www_form(query_to_sign)
         )
-        query = ShopifyAPI::Auth::Oauth::AuthQuery.new(
-          code: "somecode",
-          shop: "some-shop.myshopify.com",
-          state: "1234",
-          timestamp: "123456",
-          host: "host",
-          hmac: hmac
-        )
-        assert(ShopifyAPI::Utils::HmacValidator.validate(query))
       end
     end
   end

--- a/test/utils/session_utils_test.rb
+++ b/test/utils/session_utils_test.rb
@@ -84,7 +84,7 @@ module ShopifyAPITest
         end
       end
 
-      def test_fails_if_authorization_header_be
+      def test_fails_if_api_secret_key_is_invalid
         modify_context(is_embedded: true)
         jwt_header = create_jwt_header("UNKNOWN_API_SECRET_KEY")
         assert_raises(ShopifyAPI::Errors::InvalidJwtTokenError) do


### PR DESCRIPTION
## Description

Fixes #990

Similar to #952 978, this library needs the ability to verify the `hmac` signature of the query string in the OAuth 2.0 callback using both ew and old API secrets in order to support [API key rotation](https://shopify.dev/apps/auth/oauth/rotate-revoke-api-credentials).

## How has this been tested?

Added new test cases to validate the signature signed with the old secret.

## Checklist:

- [x] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the project documentation.
- [x] I have added a changelog line.
