### PR TITLE
Add missing fileutils requirement

### DIFF
--- a/lib/shopify_api/auth/file_session_storage.rb
+++ b/lib/shopify_api/auth/file_session_storage.rb
@@ -1,6 +1,8 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "fileutils"
+
 module ShopifyAPI
   module Auth
     class FileSessionStorage


### PR DESCRIPTION
If the session storage path doesn't exist, the code calls `FileUtils.mkdir_p`, so we need to make sure `fileutils` is required here.

## Checklist:

- [ ] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have performed a self-review of my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the project documentation.
- [ ] I have added a changelog line.