### PR TITLE
Shipping zone fix

### DIFF
--- a/lib/shopify_api/rest/resources/2021_10/shipping_zone.rb
+++ b/lib/shopify_api/rest/resources/2021_10/shipping_zone.rb
@@ -21,7 +21,7 @@ module ShopifyAPI
       @id = T.let(nil, T.nilable(Integer))
       @location_group_id = T.let(nil, T.nilable(Integer))
       @name = T.let(nil, T.nilable(String))
-      @price_based_shipping_rates = T.let(nil, T.nilable(T::Hash[T.untyped, T.untyped]))
+      @price_based_shipping_rates = T.let(nil, T.nilable(T::Array[T::Hash[T.untyped, T.untyped]]))
       @profile_id = T.let(nil, T.nilable(Integer))
       @provinces = T.let(nil, T.nilable(T::Array[T.untyped]))
       @weight_based_shipping_rates = T.let(nil, T.nilable(T::Array[T::Hash[T.untyped, T.untyped]]))
@@ -46,7 +46,7 @@ module ShopifyAPI
     attr_reader :location_group_id
     sig { returns(T.nilable(String)) }
     attr_reader :name
-    sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
+    sig { returns(T.nilable(T::Array[T::Hash[T.untyped, T.untyped]])) }
     attr_reader :price_based_shipping_rates
     sig { returns(T.nilable(Integer)) }
     attr_reader :profile_id

--- a/lib/shopify_api/rest/resources/2021_10/shipping_zone.rb
+++ b/lib/shopify_api/rest/resources/2021_10/shipping_zone.rb
@@ -24,7 +24,7 @@ module ShopifyAPI
       @price_based_shipping_rates = T.let(nil, T.nilable(T::Hash[T.untyped, T.untyped]))
       @profile_id = T.let(nil, T.nilable(Integer))
       @provinces = T.let(nil, T.nilable(T::Array[T.untyped]))
-      @weight_based_shipping_rates = T.let(nil, T.nilable(T::Hash[T.untyped, T.untyped]))
+      @weight_based_shipping_rates = T.let(nil, T.nilable(T::Array[T::Hash[T.untyped, T.untyped]]))
     end
 
     @has_one = T.let({}, T::Hash[Symbol, Class])
@@ -52,7 +52,7 @@ module ShopifyAPI
     attr_reader :profile_id
     sig { returns(T.nilable(T::Array[Province])) }
     attr_reader :provinces
-    sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
+    sig { returns(T.nilable(T::Array[T::Hash[T.untyped, T.untyped]])) }
     attr_reader :weight_based_shipping_rates
 
     class << self

--- a/lib/shopify_api/rest/resources/2022_01/shipping_zone.rb
+++ b/lib/shopify_api/rest/resources/2022_01/shipping_zone.rb
@@ -21,7 +21,7 @@ module ShopifyAPI
       @id = T.let(nil, T.nilable(Integer))
       @location_group_id = T.let(nil, T.nilable(Integer))
       @name = T.let(nil, T.nilable(String))
-      @price_based_shipping_rates = T.let(nil, T.nilable(T::Hash[T.untyped, T.untyped]))
+      @price_based_shipping_rates = T.let(nil, T.nilable(T::Array[T::Hash[T.untyped, T.untyped]]))
       @profile_id = T.let(nil, T.nilable(Integer))
       @provinces = T.let(nil, T.nilable(T::Array[T.untyped]))
       @weight_based_shipping_rates = T.let(nil, T.nilable(T::Array[T::Hash[T.untyped, T.untyped]]))
@@ -46,7 +46,7 @@ module ShopifyAPI
     attr_reader :location_group_id
     sig { returns(T.nilable(String)) }
     attr_reader :name
-    sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
+    sig { returns(T.nilable(T::Array[T::Hash[T.untyped, T.untyped]])) }
     attr_reader :price_based_shipping_rates
     sig { returns(T.nilable(Integer)) }
     attr_reader :profile_id

--- a/lib/shopify_api/rest/resources/2022_01/shipping_zone.rb
+++ b/lib/shopify_api/rest/resources/2022_01/shipping_zone.rb
@@ -24,7 +24,7 @@ module ShopifyAPI
       @price_based_shipping_rates = T.let(nil, T.nilable(T::Hash[T.untyped, T.untyped]))
       @profile_id = T.let(nil, T.nilable(Integer))
       @provinces = T.let(nil, T.nilable(T::Array[T.untyped]))
-      @weight_based_shipping_rates = T.let(nil, T.nilable(T::Hash[T.untyped, T.untyped]))
+      @weight_based_shipping_rates = T.let(nil, T.nilable(T::Array[T::Hash[T.untyped, T.untyped]]))
     end
 
     @has_one = T.let({}, T::Hash[Symbol, Class])
@@ -52,7 +52,7 @@ module ShopifyAPI
     attr_reader :profile_id
     sig { returns(T.nilable(T::Array[Province])) }
     attr_reader :provinces
-    sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
+    sig { returns(T.nilable(T::Array[T::Hash[T.untyped, T.untyped]])) }
     attr_reader :weight_based_shipping_rates
 
     class << self

--- a/lib/shopify_api/rest/resources/2022_04/shipping_zone.rb
+++ b/lib/shopify_api/rest/resources/2022_04/shipping_zone.rb
@@ -21,7 +21,7 @@ module ShopifyAPI
       @id = T.let(nil, T.nilable(Integer))
       @location_group_id = T.let(nil, T.nilable(Integer))
       @name = T.let(nil, T.nilable(String))
-      @price_based_shipping_rates = T.let(nil, T.nilable(T::Hash[T.untyped, T.untyped]))
+      @price_based_shipping_rates = T.let(nil, T.nilable(T::Array[T::Hash[T.untyped, T.untyped]]))
       @profile_id = T.let(nil, T.nilable(Integer))
       @provinces = T.let(nil, T.nilable(T::Array[T.untyped]))
       @weight_based_shipping_rates = T.let(nil, T.nilable(T::Array[T::Hash[T.untyped, T.untyped]]))
@@ -46,7 +46,7 @@ module ShopifyAPI
     attr_reader :location_group_id
     sig { returns(T.nilable(String)) }
     attr_reader :name
-    sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
+    sig { returns(T.nilable(T::Array[T::Hash[T.untyped, T.untyped]])) }
     attr_reader :price_based_shipping_rates
     sig { returns(T.nilable(Integer)) }
     attr_reader :profile_id

--- a/lib/shopify_api/rest/resources/2022_04/shipping_zone.rb
+++ b/lib/shopify_api/rest/resources/2022_04/shipping_zone.rb
@@ -24,7 +24,7 @@ module ShopifyAPI
       @price_based_shipping_rates = T.let(nil, T.nilable(T::Hash[T.untyped, T.untyped]))
       @profile_id = T.let(nil, T.nilable(Integer))
       @provinces = T.let(nil, T.nilable(T::Array[T.untyped]))
-      @weight_based_shipping_rates = T.let(nil, T.nilable(T::Hash[T.untyped, T.untyped]))
+      @weight_based_shipping_rates = T.let(nil, T.nilable(T::Array[T::Hash[T.untyped, T.untyped]]))
     end
 
     @has_one = T.let({}, T::Hash[Symbol, Class])
@@ -52,7 +52,7 @@ module ShopifyAPI
     attr_reader :profile_id
     sig { returns(T.nilable(T::Array[Province])) }
     attr_reader :provinces
-    sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
+    sig { returns(T.nilable(T::Array[T::Hash[T.untyped, T.untyped]])) }
     attr_reader :weight_based_shipping_rates
 
     class << self

--- a/lib/shopify_api/rest/resources/2022_07/shipping_zone.rb
+++ b/lib/shopify_api/rest/resources/2022_07/shipping_zone.rb
@@ -21,7 +21,7 @@ module ShopifyAPI
       @id = T.let(nil, T.nilable(Integer))
       @location_group_id = T.let(nil, T.nilable(Integer))
       @name = T.let(nil, T.nilable(String))
-      @price_based_shipping_rates = T.let(nil, T.nilable(T::Hash[T.untyped, T.untyped]))
+      @price_based_shipping_rates = T.let(nil, T.nilable(T::Array[T::Hash[T.untyped, T.untyped]]))
       @profile_id = T.let(nil, T.nilable(Integer))
       @provinces = T.let(nil, T.nilable(T::Array[T.untyped]))
       @weight_based_shipping_rates = T.let(nil, T.nilable(T::Array[T::Hash[T.untyped, T.untyped]]))
@@ -46,7 +46,7 @@ module ShopifyAPI
     attr_reader :location_group_id
     sig { returns(T.nilable(String)) }
     attr_reader :name
-    sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
+    sig { returns(T.nilable(T::Array[T::Hash[T.untyped, T.untyped]])) }
     attr_reader :price_based_shipping_rates
     sig { returns(T.nilable(Integer)) }
     attr_reader :profile_id

--- a/lib/shopify_api/rest/resources/2022_07/shipping_zone.rb
+++ b/lib/shopify_api/rest/resources/2022_07/shipping_zone.rb
@@ -24,7 +24,7 @@ module ShopifyAPI
       @price_based_shipping_rates = T.let(nil, T.nilable(T::Hash[T.untyped, T.untyped]))
       @profile_id = T.let(nil, T.nilable(Integer))
       @provinces = T.let(nil, T.nilable(T::Array[T.untyped]))
-      @weight_based_shipping_rates = T.let(nil, T.nilable(T::Hash[T.untyped, T.untyped]))
+      @weight_based_shipping_rates = T.let(nil, T.nilable(T::Array[T::Hash[T.untyped, T.untyped]]))
     end
 
     @has_one = T.let({}, T::Hash[Symbol, Class])
@@ -52,7 +52,7 @@ module ShopifyAPI
     attr_reader :profile_id
     sig { returns(T.nilable(T::Array[Province])) }
     attr_reader :provinces
-    sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
+    sig { returns(T.nilable(T::Array[T::Hash[T.untyped, T.untyped]])) }
     attr_reader :weight_based_shipping_rates
 
     class << self


### PR DESCRIPTION
## Description

- Update `ShippingZone#price_based_shipping_rates`'s type from Hash to Array
- Update `ShippingZone#weight_based_shipping_rates`'s type from Hash to Array

Otherwise, I will get below error when access those two attributes.

```
Return value: Expected type T.nilable(T::Hash[T.untyped, T.untyped]), got type Array with value ...
```
