### PR TITLE
Increase session token JWT leeway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Note: For changes to the API, see https://shopify.dev/changelog?filter=api
 
 ## Unreleased
 
+- [#1008](https://github.com/Shopify/shopify-api-ruby/pull/1008) Increase session token JWT validation leeway from 5s to 10s
+
 ## Version 11.1.0
 
 - [#1002](https://github.com/Shopify/shopify-api-ruby/pull/1002) Add new method to construct the host app URL for an embedded app, allowing for safer redirect to app inside appropriate shop admin

--- a/lib/shopify_api/auth/jwt_payload.rb
+++ b/lib/shopify_api/auth/jwt_payload.rb
@@ -6,7 +6,7 @@ module ShopifyAPI
     class JwtPayload
       extend T::Sig
 
-      JWT_EXPIRATION_LEEWAY = 5
+      JWT_EXPIRATION_LEEWAY = 10
 
       sig { returns(String) }
       attr_reader :iss, :dest, :aud, :sub, :jti, :sid


### PR DESCRIPTION
### WHY are these changes introduced?

We currently have a 5s grace period for validating JWTs from session token, but there are cases where that is not long enough and we still end up failing to validate the token.

### WHAT is this pull request doing?

Increase the period to 10s which seems to eliminate the problem for good.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
