### PR TITLE
Adds "Stale" and "Waiting for Response" labels

### DIFF
--- a/.github/workflows/remove-labels-on-activity copy.yml
+++ b/.github/workflows/remove-labels-on-activity copy.yml
@@ -1,0 +1,16 @@
+name: Remove Stale or Waiting Labels
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+jobs:
+  remove-labels-on-activity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-ecosystem/action-remove-labels@v1
+        if: contains(github.event.issue.labels.*.name, 'Waiting for Response')
+        with:
+          labels: |
+            Waiting for Response
+

--- a/.github/workflows/remove-labels-on-activity.yml
+++ b/.github/workflows/remove-labels-on-activity.yml
@@ -1,0 +1,16 @@
+name: Remove Stale or Waiting Labels
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+jobs:
+  remove-labels-on-activity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-ecosystem/action-remove-labels@v1
+        if: contains(github.event.issue.labels.*.name, 'Waiting for Response')
+        with:
+          labels: |
+            Waiting for Response
+

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,31 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v5
+        with:
+          days-before-issue-stale: 90
+          days-before-issue-close: 14
+          stale-issue-label: "Stale"
+          stale-issue-message: >
+            This issue is stale because it has been open for 90 days with no activity. It will be closed if no further action occurs in 14 days. 
+          close-issue-message: |
+            We are closing this issue because it has been inactive for a few months. 
+            This probably means that it is not reproducible or it has been fixed in a newer version. 
+            If it’s an enhancement and hasn’t been taken on since it was submitted, then it seems other issues have taken priority.
+
+            If you still encounter this issue with the latest stable version, please reopen using the issue template. You can also contribute directly by submitting a pull request– see the [CONTRIBUTING.md](https://github.com/Shopify/shopify-api-ruby/blob/main/CONTRIBUTING.md) file for guidelines
+
+            Thank you!
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          exempt-issue-labels: "feature request"


### PR DESCRIPTION
## Description

Working on https://github.com/Shopify/first-party-library-planning/issues/458

This PR adds two new labels "Stale" and "Waiting for Response". Stale will be added to any issue that hasn't had activity for 90 days. If an issue is labeled as "Stale" and dose not have activity for an additional 14 days it will be closed automatically. The "Waiting for Response" label is added manually to an issue, if one of our devs is waiting for clarifications on a ticket. If the ticket doesn't see activity for 7 days it will be closed automatically. If it does see activity then the label is removed automatically.

## How has this been tested?

I have tested these workflows in [shopify_app](https://github.com/Shopify/shopify_app)

## Checklist:

- [ ] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [ ] I have performed a self-review of my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the project documentation.
- [ ] I have added a changelog line.
