### PR TITLE
Allow custom scopes during the auth process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Note: For changes to the API, see https://shopify.dev/changelog?filter=api
 
 ## Unreleased
 
+- [#1023](https://github.com/Shopify/shopify-api-ruby/pull/1023) Allow custom scopes during the OAuth process
+
 ## Version 12.1.0
 
 - [#1017](https://github.com/Shopify/shopify-api-ruby/pull/1017) Add support for `http` with localhost development without using a TLS tunnel

--- a/lib/shopify_api/auth/oauth.rb
+++ b/lib/shopify_api/auth/oauth.rb
@@ -16,9 +16,18 @@ module ShopifyAPI
             shop: String,
             redirect_path: String,
             is_online: T.nilable(T::Boolean),
+            scope_override: T.nilable(T.any(ShopifyAPI::Auth::AuthScopes, T::Array[String], String)),
           ).returns(T::Hash[Symbol, T.any(String, SessionCookie)])
         end
-        def begin_auth(shop:, redirect_path:, is_online: true)
+        def begin_auth(shop:, redirect_path:, is_online: true, scope_override: nil)
+          scope = if scope_override.nil?
+            ShopifyAPI::Context.scope
+          elsif scope_override.is_a?(ShopifyAPI::Auth::AuthScopes)
+            scope_override
+          else
+            ShopifyAPI::Auth::AuthScopes.new(scope_override)
+          end
+
           unless Context.setup?
             raise Errors::ContextNotSetupError, "ShopifyAPI::Context not setup, please call ShopifyAPI::Context.setup"
           end
@@ -30,7 +39,7 @@ module ShopifyAPI
 
           query = {
             client_id: ShopifyAPI::Context.api_key,
-            scope: ShopifyAPI::Context.scope.to_s,
+            scope: scope.to_s,
             redirect_uri: "#{ShopifyAPI::Context.host}#{redirect_path}",
             state: state,
             "grant_options[]": is_online ? "per-user" : "",

--- a/test/auth/oauth_test.rb
+++ b/test/auth/oauth_test.rb
@@ -85,6 +85,27 @@ module ShopifyAPITest
         verify_oauth_begin(auth_route: result[:auth_route], cookie: result[:cookie], is_online: true)
       end
 
+      def test_custom_scope_with_auth_scopes
+        result = ShopifyAPI::Auth::Oauth.begin_auth(shop: @shop, redirect_path: "/redirect",
+          scope_override: ShopifyAPI::Auth::AuthScopes.new("read_orders,write_products"))
+        verify_oauth_begin(auth_route: result[:auth_route], cookie: result[:cookie], is_online: true,
+          scope: "read_orders,write_products")
+      end
+
+      def test_custom_scope_with_array_of_strings
+        result = ShopifyAPI::Auth::Oauth.begin_auth(shop: @shop, redirect_path: "/redirect",
+          scope_override: ["read_orders", "write_products"])
+        verify_oauth_begin(auth_route: result[:auth_route], cookie: result[:cookie], is_online: true,
+          scope: "read_orders,write_products")
+      end
+
+      def test_custom_scope_with_a_comma_separated_string
+        result = ShopifyAPI::Auth::Oauth.begin_auth(shop: @shop, redirect_path: "/redirect",
+          scope_override: ["read_orders,write_products"])
+        verify_oauth_begin(auth_route: result[:auth_route], cookie: result[:cookie], is_online: true,
+          scope: "read_orders,write_products")
+      end
+
       def test_begin_auth_context_not_setup
         modify_context(api_key: "", api_secret_key: "", host_name: "")
 
@@ -280,10 +301,10 @@ module ShopifyAPITest
 
       private
 
-      def verify_oauth_begin(auth_route:, cookie:, is_online:)
+      def verify_oauth_begin(auth_route:, cookie:, is_online:, scope: ShopifyAPI::Context.scope)
         expected_query_params = {
           client_id: ShopifyAPI::Context.api_key,
-          scope: ShopifyAPI::Context.scope.to_s,
+          scope: scope.to_s,
           redirect_uri: "https://#{ShopifyAPI::Context.host_name}/redirect",
           "grant_options[]": is_online ? "per-user" : "",
         }


### PR DESCRIPTION
## Description

First party apps such as https://shopify-graphiql-app.shopifycloud.com have scopes which are set during installation, rather than being preconfigured.

There is a corresponding update to `shopify_app`: https://github.com/Shopify/shopify_app/pull/1540

## How has this been tested?

Tested as part of the upgrade of https://shopify-graphiql-app.shopifycloud.com

## Checklist:

- [x] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] ~I have updated the project documentation~ N/A
- [x] I have added a changelog line.
