### PR TITLE
Update README.md for Custom Apps and Setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ ShopifyAPI::Context.setup(
 )
 ```
 
+*Important*: If you are using custom apps you will need to use the value of your access_token instead of api_secret_key
+
 ### Setup a Session Store
 
 In order for the Shopify API gem to properly store sessions it needs an implementation of `ShopifyAPI::Auth::SessionStorage`. We provide one implementation in the gem, `ShopifyAPI::Auth::FileSessionStorage`, which is suitable for testing/development, but isn't intended for production apps. See the [Session Storage doc](docs/usage/session_storage.md) for instructions on how to create a custom session store for a production application.


### PR DESCRIPTION
## Description

Custom apps have a different credential structure than the deprecated private apps. The AccessToken has replaced the old `api_secret_key` value.

- What is the problem it is solving?
Private apps were deprecated, and instructions on configuring Setup properly for regular custom apps were never added.

## How has this been tested?
* Tested by integrating with Shopify with both Rest and GQL on version `2022-07`, gem version: `11.1.0`

## Checklist:

- [ ] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have performed a self-review of my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the project documentation.
- [ ] I have added a changelog line.
