### PR TITLE
Fix typo in session_storage.md

### DIFF
--- a/docs/usage/session_storage.md
+++ b/docs/usage/session_storage.md
@@ -5,7 +5,7 @@ The implementation of session storage that you pass in `ShopifyAPI::Context.setu
 
 ## Create a New Session Storage Class
 
-You can create a session storage class that includes `ShopifyAPI::Auth::SessionStore` and override the methods as shown in the table and example below:
+You can create a session storage class that includes `ShopifyAPI::Auth::SessionStorage` and override the methods as shown in the table and example below:
 
 |       Method Name      |             Input Type            |           Return Type          |
 | ---------------------- | --------------------------------- | ------------------------------ |


### PR DESCRIPTION
## Description

session storage document is wrong
`ShopifyAPI::Auth::SessionStore` is not exist.

## How has this been tested?

no change codebase

## Checklist:

- [x] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [ ] I have performed a self-review of my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the project documentation.
- [ ] I have added a changelog line.
