### PR TITLE
Remove mentions of private apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ To follow these usage guides, you will need to:
 
 - have a working knowledge of ruby and a web framework such as Rails or Sinatra
 - have a Shopify Partner account and development store
-- _OR_ have a test store where you can create a private app
 - have an app already set up in your test store or partner account
 - add the URL and the appropriate redirect for your OAuth callback route to your app settings
 
@@ -55,7 +54,6 @@ ShopifyAPI::Context.setup(
   scope: "read_orders,read_products,etc",
   session_storage: ShopifyAPI::Auth::FileSessionStorage.new, # See more details below
   is_embedded: true, # Set to true if you are building an embedded app
-  is_private: false, # Set to true if you are building a private app
   api_version: "2022-01" # The version of the API you would like to use
 )
 ```
@@ -68,7 +66,7 @@ Session information would is typically stored in cookies on the browser. However
 
 ### Performing OAuth
 
-Next, unless you are making a private app, you need to go through OAuth as described [here](https://shopify.dev/apps/auth/oauth) to create sessions for shops using your app.
+You need to go through OAuth as described [here](https://shopify.dev/apps/auth/oauth) to create sessions for shops using your app.
 The Shopify API gem tries to make this easy by providing functions to begin and complete the OAuth process. See the [Oauth doc](docs/usage/oauth.md) for instructions on how to use these.
 
 ### Register Webhooks and a Webhook Handler

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ ShopifyAPI::Context.setup(
   session_storage: ShopifyAPI::Auth::FileSessionStorage.new, # See more details below
   is_embedded: true, # Set to true if you are building an embedded app
   api_version: "2022-01" # The version of the API you would like to use
-  is_private: false, # Set to true if you are have an existing private app
+  is_private: false, # Set to true if you have an existing private app
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ ShopifyAPI::Context.setup(
   session_storage: ShopifyAPI::Auth::FileSessionStorage.new, # See more details below
   is_embedded: true, # Set to true if you are building an embedded app
   api_version: "2022-01" # The version of the API you would like to use
+  is_private: false, # Set to true if you are have an existing private app
 )
 ```
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -5,7 +5,7 @@ This page will outline everything you need to know and the steps you need to fol
 ## Requirements
 
 - A working knowledge of ruby and a web framework such as Rails or Sinatra
-- A private or custom app already set up in your test store or partner account
+- A custom app already set up in your test store or partner account
 - We recommend `ngrok` to tunnel traffic to your localhost for testing
 
 ## Installation
@@ -28,7 +28,6 @@ ShopifyAPI::Context.setup(
   scope: "read_orders,read_products,etc",
   session_storage: ShopifyAPI::Auth::FileSessionStorage.new, # This is only to be used for testing, more information in session docs
   is_embedded: true, # Set to true if you are building an embedded app
-  is_private: false, # Set to true if you are building a private app
   api_version: "2021-01" # The vesion of the API you would like to use
 )
 ```

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -28,6 +28,7 @@ ShopifyAPI::Context.setup(
   scope: "read_orders,read_products,etc",
   session_storage: ShopifyAPI::Auth::FileSessionStorage.new, # This is only to be used for testing, more information in session docs
   is_embedded: true, # Set to true if you are building an embedded app
+  is_private: false, # Set to true if you are building a private app
   api_version: "2021-01" # The vesion of the API you would like to use
 )
 ```

--- a/docs/usage/oauth.md
+++ b/docs/usage/oauth.md
@@ -3,8 +3,7 @@
 Once the library is set up for your project, you'll be able to use it to start adding functionality to your app. The first thing your app will need to do is to obtain an access token to the Admin API by performing the OAuth process.
 
 To do this, you can follow the steps below.
-
-**Note:** You do not need to go through the OAuth process if you are creating a private app. In this case you can simply set your `<key+password>` as the `api_secret_key` in `ShopifyAPI::Context.setup`. For more information on authenticating a Shopify app please see the [Types of Authentication](https://shopify.dev/apps/auth#types-of-authentication) page.
+For more information on authenticating a Shopify app please see the [Types of Authentication](https://shopify.dev/apps/auth#types-of-authentication) page.
 
 ## Add a route to start OAuth
 
@@ -53,7 +52,7 @@ def callback
       cookies: cookies.to_h,
       auth_query: ShopifyAPI::Auth::Oauth::AuthQuery.new(request.parameters.symbolize_keys.except(:controller, :action))
     )
-    
+
     cookies[auth_result[:cookie].name] = {
       expires: auth_result[:cookie].expires,
       secure: true,
@@ -66,7 +65,7 @@ def callback
     head 307
     response.set_header("Location", "<some-redirect-url>")
   rescue => e
-    puts(e.message)  
+    puts(e.message)
     head 500
   end
 end


### PR DESCRIPTION
As per https://help.shopify.com/en/manual/apps/private-apps

> Private apps are deprecated and can't be created as of January 2022. Ask your app developer to create a [custom app](https://help.shopify.com/en/manual/apps/app-types#custom-apps). Like private apps, custom apps are built exclusively for your shop, but they don't require open API access to your store or access to your Shopify admin.