### PR TITLE
Fix: FulfillmentEvent returns String for province and country

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Note: For changes to the API, see https://shopify.dev/changelog?filter=api
 
 ## Unreleased
 
+- [#1071](https://github.com/Shopify/shopify-api-ruby/issues/1071) Fix FulfillmentEvent class types
+
 ## Version 12.4.0
 
 - [#1092](https://github.com/Shopify/shopify-api-ruby/pull/1092) Add support for 2023-01 API version.

--- a/lib/shopify_api/rest/resources/2022_01/fulfillment_event.rb
+++ b/lib/shopify_api/rest/resources/2022_01/fulfillment_event.rb
@@ -18,7 +18,7 @@ module ShopifyAPI
 
       @address1 = T.let(nil, T.nilable(String))
       @city = T.let(nil, T.nilable(String))
-      @country = T.let(nil, T.nilable(Country))
+      @country = T.let(nil, T.nilable(String))
       @created_at = T.let(nil, T.nilable(String))
       @estimated_delivery_at = T.let(nil, T.nilable(String))
       @fulfillment_id = T.let(nil, T.nilable(Integer))
@@ -28,17 +28,14 @@ module ShopifyAPI
       @longitude = T.let(nil, T.nilable(Float))
       @message = T.let(nil, T.nilable(String))
       @order_id = T.let(nil, T.nilable(Integer))
-      @province = T.let(nil, T.nilable(Province))
+      @province = T.let(nil, T.nilable(String))
       @shop_id = T.let(nil, T.nilable(Integer))
       @status = T.let(nil, T.nilable(String))
       @updated_at = T.let(nil, T.nilable(String))
       @zip = T.let(nil, T.nilable(String))
     end
 
-    @has_one = T.let({
-      country: Country,
-      province: Province
-    }, T::Hash[Symbol, Class])
+    @has_one = T.let({}, T::Hash[Symbol, Class])
     @has_many = T.let({}, T::Hash[Symbol, Class])
     @paths = T.let([
       {http_method: :delete, operation: :delete, ids: [:order_id, :fulfillment_id, :id], path: "orders/<order_id>/fulfillments/<fulfillment_id>/events/<id>.json"},
@@ -51,7 +48,7 @@ module ShopifyAPI
     attr_reader :address1
     sig { returns(T.nilable(String)) }
     attr_reader :city
-    sig { returns(T.nilable(Country)) }
+    sig { returns(T.nilable(String)) }
     attr_reader :country
     sig { returns(T.nilable(String)) }
     attr_reader :created_at
@@ -71,7 +68,7 @@ module ShopifyAPI
     attr_reader :message
     sig { returns(T.nilable(Integer)) }
     attr_reader :order_id
-    sig { returns(T.nilable(Province)) }
+    sig { returns(T.nilable(String)) }
     attr_reader :province
     sig { returns(T.nilable(Integer)) }
     attr_reader :shop_id

--- a/lib/shopify_api/rest/resources/2022_01/inventory_item.rb
+++ b/lib/shopify_api/rest/resources/2022_01/inventory_item.rb
@@ -20,7 +20,7 @@ module ShopifyAPI
       @country_code_of_origin = T.let(nil, T.nilable(String))
       @country_harmonized_system_codes = T.let(nil, T.nilable(T::Array[T.untyped]))
       @created_at = T.let(nil, T.nilable(String))
-      @harmonized_system_code = T.let(nil, T.nilable(Integer))
+      @harmonized_system_code = T.let(nil, T.nilable(T.any(Integer, String)))
       @id = T.let(nil, T.nilable(Integer))
       @province_code_of_origin = T.let(nil, T.nilable(String))
       @requires_shipping = T.let(nil, T.nilable(T::Boolean))
@@ -45,7 +45,7 @@ module ShopifyAPI
     attr_reader :country_harmonized_system_codes
     sig { returns(T.nilable(String)) }
     attr_reader :created_at
-    sig { returns(T.nilable(Integer)) }
+    sig { returns(T.nilable(T.any(Integer, String))) }
     attr_reader :harmonized_system_code
     sig { returns(T.nilable(Integer)) }
     attr_reader :id

--- a/lib/shopify_api/rest/resources/2022_04/fulfillment_event.rb
+++ b/lib/shopify_api/rest/resources/2022_04/fulfillment_event.rb
@@ -18,7 +18,7 @@ module ShopifyAPI
 
       @address1 = T.let(nil, T.nilable(String))
       @city = T.let(nil, T.nilable(String))
-      @country = T.let(nil, T.nilable(Country))
+      @country = T.let(nil, T.nilable(String))
       @created_at = T.let(nil, T.nilable(String))
       @estimated_delivery_at = T.let(nil, T.nilable(String))
       @fulfillment_id = T.let(nil, T.nilable(Integer))
@@ -28,17 +28,14 @@ module ShopifyAPI
       @longitude = T.let(nil, T.nilable(Float))
       @message = T.let(nil, T.nilable(String))
       @order_id = T.let(nil, T.nilable(Integer))
-      @province = T.let(nil, T.nilable(Province))
+      @province = T.let(nil, T.nilable(String))
       @shop_id = T.let(nil, T.nilable(Integer))
       @status = T.let(nil, T.nilable(String))
       @updated_at = T.let(nil, T.nilable(String))
       @zip = T.let(nil, T.nilable(String))
     end
 
-    @has_one = T.let({
-      country: Country,
-      province: Province
-    }, T::Hash[Symbol, Class])
+    @has_one = T.let({}, T::Hash[Symbol, Class])
     @has_many = T.let({}, T::Hash[Symbol, Class])
     @paths = T.let([
       {http_method: :delete, operation: :delete, ids: [:order_id, :fulfillment_id, :id], path: "orders/<order_id>/fulfillments/<fulfillment_id>/events/<id>.json"},
@@ -51,7 +48,7 @@ module ShopifyAPI
     attr_reader :address1
     sig { returns(T.nilable(String)) }
     attr_reader :city
-    sig { returns(T.nilable(Country)) }
+    sig { returns(T.nilable(String)) }
     attr_reader :country
     sig { returns(T.nilable(String)) }
     attr_reader :created_at
@@ -71,7 +68,7 @@ module ShopifyAPI
     attr_reader :message
     sig { returns(T.nilable(Integer)) }
     attr_reader :order_id
-    sig { returns(T.nilable(Province)) }
+    sig { returns(T.nilable(String)) }
     attr_reader :province
     sig { returns(T.nilable(Integer)) }
     attr_reader :shop_id

--- a/lib/shopify_api/rest/resources/2022_04/inventory_item.rb
+++ b/lib/shopify_api/rest/resources/2022_04/inventory_item.rb
@@ -20,7 +20,7 @@ module ShopifyAPI
       @country_code_of_origin = T.let(nil, T.nilable(String))
       @country_harmonized_system_codes = T.let(nil, T.nilable(T::Array[T.untyped]))
       @created_at = T.let(nil, T.nilable(String))
-      @harmonized_system_code = T.let(nil, T.nilable(Integer))
+      @harmonized_system_code = T.let(nil, T.nilable(T.any(Integer, String)))
       @id = T.let(nil, T.nilable(Integer))
       @province_code_of_origin = T.let(nil, T.nilable(String))
       @requires_shipping = T.let(nil, T.nilable(T::Boolean))
@@ -45,7 +45,7 @@ module ShopifyAPI
     attr_reader :country_harmonized_system_codes
     sig { returns(T.nilable(String)) }
     attr_reader :created_at
-    sig { returns(T.nilable(Integer)) }
+    sig { returns(T.nilable(T.any(Integer, String))) }
     attr_reader :harmonized_system_code
     sig { returns(T.nilable(Integer)) }
     attr_reader :id

--- a/lib/shopify_api/rest/resources/2022_07/fulfillment_event.rb
+++ b/lib/shopify_api/rest/resources/2022_07/fulfillment_event.rb
@@ -18,7 +18,7 @@ module ShopifyAPI
 
       @address1 = T.let(nil, T.nilable(String))
       @city = T.let(nil, T.nilable(String))
-      @country = T.let(nil, T.nilable(Country))
+      @country = T.let(nil, T.nilable(String))
       @created_at = T.let(nil, T.nilable(String))
       @estimated_delivery_at = T.let(nil, T.nilable(String))
       @fulfillment_id = T.let(nil, T.nilable(Integer))
@@ -28,17 +28,14 @@ module ShopifyAPI
       @longitude = T.let(nil, T.nilable(Float))
       @message = T.let(nil, T.nilable(String))
       @order_id = T.let(nil, T.nilable(Integer))
-      @province = T.let(nil, T.nilable(Province))
+      @province = T.let(nil, T.nilable(String))
       @shop_id = T.let(nil, T.nilable(Integer))
       @status = T.let(nil, T.nilable(String))
       @updated_at = T.let(nil, T.nilable(String))
       @zip = T.let(nil, T.nilable(String))
     end
 
-    @has_one = T.let({
-      country: Country,
-      province: Province
-    }, T::Hash[Symbol, Class])
+    @has_one = T.let({}, T::Hash[Symbol, Class])
     @has_many = T.let({}, T::Hash[Symbol, Class])
     @paths = T.let([
       {http_method: :delete, operation: :delete, ids: [:order_id, :fulfillment_id, :id], path: "orders/<order_id>/fulfillments/<fulfillment_id>/events/<id>.json"},
@@ -51,7 +48,7 @@ module ShopifyAPI
     attr_reader :address1
     sig { returns(T.nilable(String)) }
     attr_reader :city
-    sig { returns(T.nilable(Country)) }
+    sig { returns(T.nilable(String)) }
     attr_reader :country
     sig { returns(T.nilable(String)) }
     attr_reader :created_at
@@ -71,7 +68,7 @@ module ShopifyAPI
     attr_reader :message
     sig { returns(T.nilable(Integer)) }
     attr_reader :order_id
-    sig { returns(T.nilable(Province)) }
+    sig { returns(T.nilable(String)) }
     attr_reader :province
     sig { returns(T.nilable(Integer)) }
     attr_reader :shop_id

--- a/lib/shopify_api/rest/resources/2022_07/inventory_item.rb
+++ b/lib/shopify_api/rest/resources/2022_07/inventory_item.rb
@@ -20,7 +20,7 @@ module ShopifyAPI
       @country_code_of_origin = T.let(nil, T.nilable(String))
       @country_harmonized_system_codes = T.let(nil, T.nilable(T::Array[T.untyped]))
       @created_at = T.let(nil, T.nilable(String))
-      @harmonized_system_code = T.let(nil, T.nilable(Integer))
+      @harmonized_system_code = T.let(nil, T.nilable(T.any(Integer, String)))
       @id = T.let(nil, T.nilable(Integer))
       @province_code_of_origin = T.let(nil, T.nilable(String))
       @requires_shipping = T.let(nil, T.nilable(T::Boolean))
@@ -45,7 +45,7 @@ module ShopifyAPI
     attr_reader :country_harmonized_system_codes
     sig { returns(T.nilable(String)) }
     attr_reader :created_at
-    sig { returns(T.nilable(Integer)) }
+    sig { returns(T.nilable(T.any(Integer, String))) }
     attr_reader :harmonized_system_code
     sig { returns(T.nilable(Integer)) }
     attr_reader :id

--- a/lib/shopify_api/rest/resources/2022_10/fulfillment_event.rb
+++ b/lib/shopify_api/rest/resources/2022_10/fulfillment_event.rb
@@ -18,7 +18,7 @@ module ShopifyAPI
 
       @address1 = T.let(nil, T.nilable(String))
       @city = T.let(nil, T.nilable(String))
-      @country = T.let(nil, T.nilable(Country))
+      @country = T.let(nil, T.nilable(String))
       @created_at = T.let(nil, T.nilable(String))
       @estimated_delivery_at = T.let(nil, T.nilable(String))
       @fulfillment_id = T.let(nil, T.nilable(Integer))
@@ -28,17 +28,14 @@ module ShopifyAPI
       @longitude = T.let(nil, T.nilable(Float))
       @message = T.let(nil, T.nilable(String))
       @order_id = T.let(nil, T.nilable(Integer))
-      @province = T.let(nil, T.nilable(Province))
+      @province = T.let(nil, T.nilable(String))
       @shop_id = T.let(nil, T.nilable(Integer))
       @status = T.let(nil, T.nilable(String))
       @updated_at = T.let(nil, T.nilable(String))
       @zip = T.let(nil, T.nilable(String))
     end
 
-    @has_one = T.let({
-      country: Country,
-      province: Province
-    }, T::Hash[Symbol, Class])
+    @has_one = T.let({}, T::Hash[Symbol, Class])
     @has_many = T.let({}, T::Hash[Symbol, Class])
     @paths = T.let([
       {http_method: :delete, operation: :delete, ids: [:order_id, :fulfillment_id, :id], path: "orders/<order_id>/fulfillments/<fulfillment_id>/events/<id>.json"},
@@ -51,7 +48,7 @@ module ShopifyAPI
     attr_reader :address1
     sig { returns(T.nilable(String)) }
     attr_reader :city
-    sig { returns(T.nilable(Country)) }
+    sig { returns(T.nilable(String)) }
     attr_reader :country
     sig { returns(T.nilable(String)) }
     attr_reader :created_at
@@ -71,7 +68,7 @@ module ShopifyAPI
     attr_reader :message
     sig { returns(T.nilable(Integer)) }
     attr_reader :order_id
-    sig { returns(T.nilable(Province)) }
+    sig { returns(T.nilable(String)) }
     attr_reader :province
     sig { returns(T.nilable(Integer)) }
     attr_reader :shop_id

--- a/lib/shopify_api/rest/resources/2022_10/inventory_item.rb
+++ b/lib/shopify_api/rest/resources/2022_10/inventory_item.rb
@@ -20,7 +20,7 @@ module ShopifyAPI
       @country_code_of_origin = T.let(nil, T.nilable(String))
       @country_harmonized_system_codes = T.let(nil, T.nilable(T::Array[T.untyped]))
       @created_at = T.let(nil, T.nilable(String))
-      @harmonized_system_code = T.let(nil, T.nilable(Integer))
+      @harmonized_system_code = T.let(nil, T.nilable(T.any(Integer, String)))
       @id = T.let(nil, T.nilable(Integer))
       @province_code_of_origin = T.let(nil, T.nilable(String))
       @requires_shipping = T.let(nil, T.nilable(T::Boolean))
@@ -45,7 +45,7 @@ module ShopifyAPI
     attr_reader :country_harmonized_system_codes
     sig { returns(T.nilable(String)) }
     attr_reader :created_at
-    sig { returns(T.nilable(Integer)) }
+    sig { returns(T.nilable(T.any(Integer, String))) }
     attr_reader :harmonized_system_code
     sig { returns(T.nilable(Integer)) }
     attr_reader :id

--- a/lib/shopify_api/rest/resources/2023_01/fulfillment_event.rb
+++ b/lib/shopify_api/rest/resources/2023_01/fulfillment_event.rb
@@ -18,7 +18,7 @@ module ShopifyAPI
 
       @address1 = T.let(nil, T.nilable(String))
       @city = T.let(nil, T.nilable(String))
-      @country = T.let(nil, T.nilable(Country))
+      @country = T.let(nil, T.nilable(String))
       @created_at = T.let(nil, T.nilable(String))
       @estimated_delivery_at = T.let(nil, T.nilable(String))
       @fulfillment_id = T.let(nil, T.nilable(Integer))
@@ -28,17 +28,14 @@ module ShopifyAPI
       @longitude = T.let(nil, T.nilable(Float))
       @message = T.let(nil, T.nilable(String))
       @order_id = T.let(nil, T.nilable(Integer))
-      @province = T.let(nil, T.nilable(Province))
+      @province = T.let(nil, T.nilable(String))
       @shop_id = T.let(nil, T.nilable(Integer))
       @status = T.let(nil, T.nilable(String))
       @updated_at = T.let(nil, T.nilable(String))
       @zip = T.let(nil, T.nilable(String))
     end
 
-    @has_one = T.let({
-      country: Country,
-      province: Province
-    }, T::Hash[Symbol, Class])
+    @has_one = T.let({}, T::Hash[Symbol, Class])
     @has_many = T.let({}, T::Hash[Symbol, Class])
     @paths = T.let([
       {http_method: :delete, operation: :delete, ids: [:order_id, :fulfillment_id, :id], path: "orders/<order_id>/fulfillments/<fulfillment_id>/events/<id>.json"},
@@ -51,7 +48,7 @@ module ShopifyAPI
     attr_reader :address1
     sig { returns(T.nilable(String)) }
     attr_reader :city
-    sig { returns(T.nilable(Country)) }
+    sig { returns(T.nilable(String)) }
     attr_reader :country
     sig { returns(T.nilable(String)) }
     attr_reader :created_at
@@ -71,7 +68,7 @@ module ShopifyAPI
     attr_reader :message
     sig { returns(T.nilable(Integer)) }
     attr_reader :order_id
-    sig { returns(T.nilable(Province)) }
+    sig { returns(T.nilable(String)) }
     attr_reader :province
     sig { returns(T.nilable(Integer)) }
     attr_reader :shop_id

--- a/lib/shopify_api/rest/resources/2023_01/inventory_item.rb
+++ b/lib/shopify_api/rest/resources/2023_01/inventory_item.rb
@@ -20,7 +20,7 @@ module ShopifyAPI
       @country_code_of_origin = T.let(nil, T.nilable(String))
       @country_harmonized_system_codes = T.let(nil, T.nilable(T::Array[T.untyped]))
       @created_at = T.let(nil, T.nilable(String))
-      @harmonized_system_code = T.let(nil, T.nilable(Integer))
+      @harmonized_system_code = T.let(nil, T.nilable(T.any(Integer, String)))
       @id = T.let(nil, T.nilable(Integer))
       @province_code_of_origin = T.let(nil, T.nilable(String))
       @requires_shipping = T.let(nil, T.nilable(T::Boolean))
@@ -45,7 +45,7 @@ module ShopifyAPI
     attr_reader :country_harmonized_system_codes
     sig { returns(T.nilable(String)) }
     attr_reader :created_at
-    sig { returns(T.nilable(Integer)) }
+    sig { returns(T.nilable(T.any(Integer, String))) }
     attr_reader :harmonized_system_code
     sig { returns(T.nilable(Integer)) }
     attr_reader :id

--- a/test/rest/2022_10/fulfillment_event_test.rb
+++ b/test/rest/2022_10/fulfillment_event_test.rb
@@ -38,7 +38,7 @@ class FulfillmentEvent202210Test < Test::Unit::TestCase
         headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json"},
         body: {}
       )
-      .to_return(status: 200, body: JSON.generate({"fulfillment_events" => [{"id" => 944956391, "fulfillment_id" => 255858046, "status" => "in_transit", "message" => nil, "happened_at" => "2023-01-03T12:58:57-05:00", "city" => nil, "province" => nil, "country" => nil, "zip" => nil, "address1" => nil, "latitude" => nil, "longitude" => nil, "shop_id" => 548380009, "created_at" => "2023-01-03T12:58:57-05:00", "updated_at" => "2023-01-03T12:58:57-05:00", "estimated_delivery_at" => nil, "order_id" => 450789469, "admin_graphql_api_id" => "gid://shopify/FulfillmentEvent/944956391"}]}), headers: {})
+      .to_return(status: 200, body: JSON.generate({"fulfillment_events" => [{"id" => 944956391, "fulfillment_id" => 255858046, "status" => "in_transit", "message" => nil, "happened_at" => "2023-01-03T12:58:57-05:00", "city" => nil, "province" => "ON", "country" => "CA", "zip" => nil, "address1" => nil, "latitude" => nil, "longitude" => nil, "shop_id" => 548380009, "created_at" => "2023-01-03T12:58:57-05:00", "updated_at" => "2023-01-03T12:58:57-05:00", "estimated_delivery_at" => nil, "order_id" => 450789469, "admin_graphql_api_id" => "gid://shopify/FulfillmentEvent/944956391"}]}), headers: {})
 
     ShopifyAPI::FulfillmentEvent.all(
       order_id: 450789469,
@@ -57,7 +57,7 @@ class FulfillmentEvent202210Test < Test::Unit::TestCase
         headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json", "Content-Type"=>"application/json"},
         body: { "event" => hash_including({"status" => "in_transit"}) }
       )
-      .to_return(status: 200, body: JSON.generate({"fulfillment_event" => {"id" => 944956392, "fulfillment_id" => 255858046, "status" => "in_transit", "message" => nil, "happened_at" => "2023-01-03T12:59:00-05:00", "city" => nil, "province" => nil, "country" => nil, "zip" => nil, "address1" => nil, "latitude" => nil, "longitude" => nil, "shop_id" => 548380009, "created_at" => "2023-01-03T12:59:00-05:00", "updated_at" => "2023-01-03T12:59:00-05:00", "estimated_delivery_at" => nil, "order_id" => 450789469, "admin_graphql_api_id" => "gid://shopify/FulfillmentEvent/944956392"}}), headers: {})
+      .to_return(status: 200, body: JSON.generate({"fulfillment_event" => {"id" => 944956392, "fulfillment_id" => 255858046, "status" => "in_transit", "message" => nil, "happened_at" => "2023-01-03T12:59:00-05:00", "city" => nil, "province" => "ON", "country" => "CA", "zip" => nil, "address1" => nil, "latitude" => nil, "longitude" => nil, "shop_id" => 548380009, "created_at" => "2023-01-03T12:59:00-05:00", "updated_at" => "2023-01-03T12:59:00-05:00", "estimated_delivery_at" => nil, "order_id" => 450789469, "admin_graphql_api_id" => "gid://shopify/FulfillmentEvent/944956392"}}), headers: {})
 
     fulfillment_event = ShopifyAPI::FulfillmentEvent.new
     fulfillment_event.order_id = 450789469
@@ -77,7 +77,7 @@ class FulfillmentEvent202210Test < Test::Unit::TestCase
         headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json"},
         body: {}
       )
-      .to_return(status: 200, body: JSON.generate({"fulfillment_event" => {"id" => 944956393, "fulfillment_id" => 255858046, "status" => "in_transit", "message" => nil, "happened_at" => "2023-01-03T12:59:00-05:00", "city" => nil, "province" => nil, "country" => nil, "zip" => nil, "address1" => nil, "latitude" => nil, "longitude" => nil, "shop_id" => 548380009, "created_at" => "2023-01-03T12:59:00-05:00", "updated_at" => "2023-01-03T12:59:00-05:00", "estimated_delivery_at" => nil, "order_id" => 450789469, "admin_graphql_api_id" => "gid://shopify/FulfillmentEvent/944956393"}}), headers: {})
+      .to_return(status: 200, body: JSON.generate({"fulfillment_event" => {"id" => 944956393, "fulfillment_id" => 255858046, "status" => "in_transit", "message" => nil, "happened_at" => "2023-01-03T12:59:00-05:00", "city" => nil, "province" => "ON", "country" => "CA", "zip" => nil, "address1" => nil, "latitude" => nil, "longitude" => nil, "shop_id" => 548380009, "created_at" => "2023-01-03T12:59:00-05:00", "updated_at" => "2023-01-03T12:59:00-05:00", "estimated_delivery_at" => nil, "order_id" => 450789469, "admin_graphql_api_id" => "gid://shopify/FulfillmentEvent/944956393"}}), headers: {})
 
     ShopifyAPI::FulfillmentEvent.find(
       order_id: 450789469,

--- a/test/rest/2023_01/inventory_item_test.rb
+++ b/test/rest/2023_01/inventory_item_test.rb
@@ -74,11 +74,12 @@ class InventoryItem202301Test < Test::Unit::TestCase
         headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json", "Content-Type"=>"application/json"},
         body: { "inventory_item" => hash_including({"sku" => "new sku"}) }
       )
-      .to_return(status: 200, body: JSON.generate({"inventory_item" => {"id" => 808950810, "sku" => "new sku", "created_at" => "2023-01-03T12:21:36-05:00", "updated_at" => "2023-01-03T12:38:07-05:00", "requires_shipping" => true, "cost" => "25.00", "country_code_of_origin" => nil, "province_code_of_origin" => nil, "harmonized_system_code" => nil, "tracked" => true, "country_harmonized_system_codes" => [], "admin_graphql_api_id" => "gid://shopify/InventoryItem/808950810"}}), headers: {})
+      .to_return(status: 200, body: JSON.generate({"inventory_item" => {"id" => 808950810, "sku" => "new sku", "created_at" => "2023-01-03T12:21:36-05:00", "updated_at" => "2023-01-03T12:38:07-05:00", "requires_shipping" => true, "cost" => "25.00", "country_code_of_origin" => nil, "province_code_of_origin" => nil, "harmonized_system_code" => 1, "tracked" => true, "country_harmonized_system_codes" => [], "admin_graphql_api_id" => "gid://shopify/InventoryItem/808950810"}}), headers: {})
 
     inventory_item = ShopifyAPI::InventoryItem.new
     inventory_item.id = 808950810
     inventory_item.sku = "new sku"
+    inventory_item.harmonized_system_code = 1
     inventory_item.save
 
     assert_requested(:put, "https://test-shop.myshopify.io/admin/api/2023-01/inventory_items/808950810.json")
@@ -93,11 +94,12 @@ class InventoryItem202301Test < Test::Unit::TestCase
         headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json", "Content-Type"=>"application/json"},
         body: { "inventory_item" => hash_including({"cost" => "25.00"}) }
       )
-      .to_return(status: 200, body: JSON.generate({"inventory_item" => {"id" => 808950810, "sku" => "IPOD2008PINK", "created_at" => "2023-01-03T12:21:36-05:00", "updated_at" => "2023-01-03T12:21:36-05:00", "requires_shipping" => true, "cost" => "25.00", "country_code_of_origin" => nil, "province_code_of_origin" => nil, "harmonized_system_code" => nil, "tracked" => true, "country_harmonized_system_codes" => [], "admin_graphql_api_id" => "gid://shopify/InventoryItem/808950810"}}), headers: {})
+      .to_return(status: 200, body: JSON.generate({"inventory_item" => {"id" => 808950810, "sku" => "IPOD2008PINK", "created_at" => "2023-01-03T12:21:36-05:00", "updated_at" => "2023-01-03T12:21:36-05:00", "requires_shipping" => true, "cost" => "25.00", "country_code_of_origin" => nil, "province_code_of_origin" => nil, "harmonized_system_code" => "1", "tracked" => true, "country_harmonized_system_codes" => [], "admin_graphql_api_id" => "gid://shopify/InventoryItem/808950810"}}), headers: {})
 
     inventory_item = ShopifyAPI::InventoryItem.new
     inventory_item.id = 808950810
     inventory_item.cost = "25.00"
+    inventory_item.harmonized_system_code = "1"
     inventory_item.save
 
     assert_requested(:put, "https://test-shop.myshopify.io/admin/api/2023-01/inventory_items/808950810.json")


### PR DESCRIPTION
## Description

Fixes [#1071](https://github.com/Shopify/shopify-api-ruby/issues/1071)

Feature: Tests for FulfillmentEvent that use non-nil `province` and `country` attributes

## How has this been tested?

Test corrected to trigger the error

## Checklist:

- [X] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [X] I have performed a self-review of my own code.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the project documentation.
- [X] I have added a changelog line.
