### PR TITLE
Don't remove gem lock file in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,6 @@ jobs:
           - 3.1
     steps:
       - uses: actions/checkout@v2
-      - name: Remove Gemfile.lock
-        run: |
-          rm -f ${GITHUB_WORKSPACE}/Gemfile.lock
       - name: Set up Ruby ${{ matrix.version }}
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
Currently, we're removing the lock file in CI, which causes things to break if there is dependency drift. We should probably delete the lock file every now and then to update things, but it shouldn't be a CI step.