### PR TITLE
Gracefully handle HTTP 204 response bodies

### DIFF
--- a/lib/shopify_api/clients/http_client.rb
+++ b/lib/shopify_api/clients/http_client.rb
@@ -48,7 +48,7 @@ module ShopifyAPI
             body: request.body.class == Hash ? T.unsafe(request.body).to_json : request.body,
           ), HTTParty::Response)
 
-          body = res.body.empty? ? {} : JSON.parse(res.body)
+          body = (res.body.nil? || res.body.empty?) ? {} : JSON.parse(res.body)
           response = HttpResponse.new(code: res.code.to_i, headers: res.headers.to_h, body: body)
 
           if response.headers["x-shopify-api-deprecated-reason"]

--- a/test/clients/http_client_test.rb
+++ b/test/clients/http_client_test.rb
@@ -71,6 +71,20 @@ module ShopifyAPITest
         verify_http_request
       end
 
+      # It doesn't really make sense for an HTTP body to ever be `nil`, but
+      # the underlying HTTParty library seems to use `nil` for the response
+      # body in situations where it doesn't need to parse it, e.g. when the
+      # response status is 204.
+      def test_request_with_nil_response_body
+        @success_body = {}
+
+        stub_request(@request.http_method, "https://#{@shop}#{@base_path}/#{@request.path}")
+          .with(body: @request.body.to_json, query: @request.query, headers: @expected_headers)
+          .to_return(body: "", headers: @response_headers, status: 204)
+
+        verify_http_request
+      end
+
       def test_request_with_no_access_token
         @session = ShopifyAPI::Auth::Session.new(shop: @shop)
         @client = ShopifyAPI::Clients::HttpClient.new(session: @session, base_path: @base_path)


### PR DESCRIPTION
## Description

Fixes #1097

Please, include a summary of what the PR is for:
### What is the problem it is solving?

The HTTP client raises a `NoMethodError` when the server responds with a 204. I believe this is because `HTTParty` doesn't bother to parse the response body in certain situations, and just supplies `nil` as the response body instead.

### What is the context of these changes?

It's not entirely clear what this question is asking. Please refer to #1097 for more context.

### What is the impact of this PR?

It allows people to use the library to do things like delete discount codes and price rules without raising an exception when Shopify responds with a 204, the expected response.

## How has this been tested?

So far, just with the gem's test suite. I wrote the test first to confirm it would trigger the failure, which it did (see screenshot). After that, I just expended the existing check for the empty body condition to also be aware of `nil` bodies.

<img width="1521" alt="Screenshot 2023-01-12 at 11 12 47 AM" src="https://user-images.githubusercontent.com/6856391/212120765-8b02608d-e841-4a70-981d-552eb7043194.png">

## Checklist:

- [x] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the project documentation.
- [ ] I have added a changelog line.
