### PR TITLE
Handle JSON::ParserError when http response is HTML and raise ShopifyAPI::Errors::HttpResponseError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Note: For changes to the API, see https://shopify.dev/changelog?filter=api
 
 ## Unreleased
+- [#1113](https://github.com/Shopify/shopify-api-ruby/pull/1113) Handle JSON::ParserError when http response is HTML and raise ShopifyAPI::Errors::HttpResponseError
 - [#1104](https://github.com/Shopify/shopify-api-ruby/pull/1104) Allow api version overrides.
 
 ## Version 12.4.0

--- a/lib/shopify_api/clients/http_client.rb
+++ b/lib/shopify_api/clients/http_client.rb
@@ -48,7 +48,12 @@ module ShopifyAPI
             body: request.body.class == Hash ? T.unsafe(request.body).to_json : request.body,
           ), HTTParty::Response)
 
-          body = res.body.empty? ? {} : JSON.parse(res.body)
+          begin
+            body = res.body.nil? || res.body.empty? ? {} : JSON.parse(res.body)
+          rescue JSON::ParserError
+            body = res.body
+          end
+
           response = HttpResponse.new(code: res.code.to_i, headers: res.headers.to_h, body: body)
 
           if response.headers["x-shopify-api-deprecated-reason"]

--- a/test/clients/http_client_test.rb
+++ b/test/clients/http_client_test.rb
@@ -204,6 +204,15 @@ module ShopifyAPITest
         assert_match(/#{@request.path}.*#{deprecate_reason}/, reader.gets)
       end
 
+      def test_json_parser_error
+        stub_request(@request.http_method, "https://#{@shop}#{@base_path}/#{@request.path}")
+          .with(body: @request.body.to_json, query: @request.query, headers: @expected_headers)
+          .to_return(body: "<html>Some HTML</html>", status: 502)
+
+        error = assert_raises(ShopifyAPI::Errors::HttpResponseError) { @client.request(@request) }
+        assert_equal(502, error.code)
+      end
+
       private
 
       def simple_http_test(http_method)


### PR DESCRIPTION
Handle `JSON::ParserError` when response is HTML and pass response body to `ShopifyAPI::Clients::HttpResponse` because it accepts body also as string.

## Description

Fixes [#1091](https://github.com/Shopify/shopify-api-ruby/issues/1091)
Fixed [#1107](https://github.com/Shopify/shopify-api-ruby/issues/1107)

Please, include a summary of what the PR is for:
- It is not possible to determine HTTP response code when response body is HTML and `JSON::ParserError` is thrown. So rescuing `JSON::ParserError` would raise `ShopifyAPI::Errors::HttpResponseError` and add response code.

## How has this been tested?

All tests passed as well as new test is included for this new functionality:
`test_json_parser_error` in `http_client_test.rb`

## Checklist:

- [x] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the project documentation.
- [x] I have added a changelog line.
