### PR TITLE
Update shopify.dev links to include /docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,13 +130,13 @@ Note: For changes to the API, see https://shopify.dev/changelog?filter=api
 ## Version 9.0.3
 
 - We now raise a `ShopifyAPI::ValidationException` exception when clients try to use `Product` and `Variant` with deprecated inventory-related fields in API version `2019-10` or later. [#655](https://github.com/Shopify/shopify-api-ruby/pull/655) Deprecation and migration information can be found in the following documents:
-  - [Product Variant REST API Reference](https://shopify.dev/docs/admin-api/rest/reference/products/product-variant)
+  - [Product Variant REST API Reference](https://shopify.dev/docs/api/admin-rest/reference/resources/product-variant)
   - [Migrate your app to support multiple locations](https://shopify.dev/tutorials/migrate-your-app-to-support-multiple-locations)
   - [Manage product inventory with the Admin API](https://shopify.dev/tutorials/manage-product-inventory-with-admin-api)
 - Added support for the Discount Code API batch endpoints [#701](https://github.com/Shopify/shopify-api-ruby/pull/701)
-  - [Create](https://shopify.dev/docs/admin-api/rest/reference/discounts/discountcode#batch_create-2020-01)
-  - [Show](https://shopify.dev/docs/admin-api/rest/reference/discounts/discountcode#batch_show-2020-01)
-  - [List](https://shopify.dev/docs/admin-api/rest/reference/discounts/discountcode#batch_discount_codes_index-2020-01)
+  - [Create](https://shopify.dev/docs/api/admin-rest/reference/resources/discountcode#batch_create-2020-01)
+  - [Show](https://shopify.dev/docs/api/admin-rest/reference/resources/discountcode#batch_show-2020-01)
+  - [List](https://shopify.dev/docs/api/admin-rest/reference/resources/discountcode#batch_discount_codes_index-2020-01)
 - Fix issue in the README to explicitly say clients need to require the `shopify_api` gem [#700](https://github.com/Shopify/shopify-api-ruby/pull/700)
 
 ## Version 9.0.2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 Submitting Issues
 -----------------
 
-Please open an issue here if you encounter a specific bug with this API client library or if something is documented here https://shopify.dev/apps but is missing from this package.
+Please open an issue here if you encounter a specific bug with this API client library or if something is documented here https://shopify.dev/docs/apps but is missing from this package.
 
 General questions about the Shopify API and usage of this package (not necessarily a bug) should be posted on the [Shopify forums](https://community.shopify.com/c/partners-and-developers/ct-p/appdev).
 

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 ![Build Status](https://github.com/Shopify/shopify-api-ruby/workflows/CI/badge.svg?branch=main)
 
-This library provides support for Ruby [Shopify apps](https://apps.shopify.com/) to access the [Shopify Admin API](https://shopify.dev/api/admin), by making it easier to perform the following actions:
+This library provides support for Ruby [Shopify apps](https://apps.shopify.com/) to access the [Shopify Admin API](https://shopify.dev/docs/api/admin), by making it easier to perform the following actions:
 
-- Creating [online](https://shopify.dev/apps/auth/oauth/access-modes#online-access) or [offline](https://shopify.dev/apps/auth/oauth/access-modes#offline-access) access tokens for the Admin API via OAuth
-- Making requests to the [REST API](https://shopify.dev/api/admin-rest)
-- Making requests to the [GraphQL API](https://shopify.dev/api/admin-graphql)
+- Creating [online](https://shopify.dev/docs/apps/auth/oauth/access-modes#online-access) or [offline](https://shopify.dev/docs/apps/auth/oauth/access-modes#offline-access) access tokens for the Admin API via OAuth
+- Making requests to the [REST API](https://shopify.dev/docs/api/admin-rest)
+- Making requests to the [GraphQL API](https://shopify.dev/docs/api/admin-graphql)
 - Registering/processing webhooks
 
-In addition to the Admin API, this library also allows querying the [Storefront API](https://shopify.dev/docs/storefront-api).
+In addition to the Admin API, this library also allows querying the [Storefront API](https://shopify.dev/docs/api/storefront).
 
 You can use this library in any application that has a Ruby backend, since it doesn't rely on any specific framework — you can include it alongside your preferred stack and use the features that you need to build your app.
 
@@ -63,11 +63,11 @@ ShopifyAPI::Context.setup(
 
 In order for the Shopify API gem to properly store sessions it needs an implementation of `ShopifyAPI::Auth::SessionStorage`. We provide one implementation in the gem, `ShopifyAPI::Auth::FileSessionStorage`, which is suitable for testing/development, but isn't intended for production apps. See the [Session Storage doc](docs/usage/session_storage.md) for instructions on how to create a custom session store for a production application.
 
-Session information would is typically stored in cookies on the browser. However, due to restrictions with modern browsers we highly discourage using cookies for embedded apps. For this reason, an app needs to define a storage implementation that the library can use to store and retrieve a session given its ID. In a non-embedded app this ID will come from a cookie, whereas in an embedded app this ID will come from [App Bridge](https://shopify.dev/apps/tools/app-bridge).
+Session information would is typically stored in cookies on the browser. However, due to restrictions with modern browsers we highly discourage using cookies for embedded apps. For this reason, an app needs to define a storage implementation that the library can use to store and retrieve a session given its ID. In a non-embedded app this ID will come from a cookie, whereas in an embedded app this ID will come from [App Bridge](https://shopify.dev/docs/apps/tools/app-bridge).
 
 ### Performing OAuth
 
-You need to go through OAuth as described [here](https://shopify.dev/apps/auth/oauth) to create sessions for shops using your app.
+You need to go through OAuth as described [here](https://shopify.dev/docs/apps/auth/oauth) to create sessions for shops using your app.
 The Shopify API gem tries to make this easy by providing functions to begin and complete the OAuth process. See the [Oauth doc](docs/usage/oauth.md) for instructions on how to use these.
 
 ### Register Webhooks and a Webhook Handler
@@ -90,7 +90,7 @@ Here are the main features it provides:
 - Full, transparent support for JWT sessions for embedded apps and cookies for non-embedded ones.
   - Removal of support for 3rd party cookies which are increasingly more difficult to use with modern browsers.
 - Admin API support
-  - Auto-generated, version-specific REST resources which are similar to `ActiveResource` (though not identical), that provide methods for all endpoints defined in our [REST API reference](https://shopify.dev/api/admin-rest), as well as direct definition of known attributes.
+  - Auto-generated, version-specific REST resources which are similar to `ActiveResource` (though not identical), that provide methods for all endpoints defined in our [REST API reference](https://shopify.dev/docs/api/admin-rest), as well as direct definition of known attributes.
   - A GraphQL client that doesn't rely on the ActiveResource implementation for REST.
 - Webhook management, with features for adding handlers and registering them with Shopify.
 - Storefront GraphQL API support
@@ -102,7 +102,7 @@ With this, a lot changed in how apps access the library. Here are the updates yo
 - Call `ShopifyAPI::Context.setup` when setting up your app. This class holds global configurations for your app and defines how the library behaves.
 - If not using the `shopify_app` gem, your app needs to provide an implementation of `ShopifyAPI::Auth::SessionStorage` for production. Read more about this [in our documentation](docs/usage/session_storage.md).
 - To change the `User-Agent` header, use `user_agent_prefix` in `ShopifyAPI::Context.setup`.
-- Usages of the `ActiveResource` classes for REST API requests need to be refactored into the new format. You can find detailed examples on how each of the endpoints work in our [reference documentation](https://shopify.dev/api/admin-rest).
+- Usages of the `ActiveResource` classes for REST API requests need to be refactored into the new format. You can find detailed examples on how each of the endpoints work in our [reference documentation](https://shopify.dev/docs/api/admin-rest).
 
     Please see below a (non-exhaustive) list of common replacements to guide you in your updates, using the `Order` resource as an example.
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -37,11 +37,11 @@ ShopifyAPI::Context.setup(
 
 In order for the Shopify API gem to properly store sessions it needs an implementation of `ShopifyAPI::Auth::SessionStorage`. There is one provided in the gem, `ShopifyAPI::Auth::FileSessionStorage`, this is suitable for testing, however it is not intended for production apps. See the [Session Storage doc](usage/session_storage.md) for instructions on how to create a custom session store for a production application.
 
-Normally session information would be stored in cookies on the browser. However, due to restrictions with modern browsers we highly discourage using cookies for embedded apps. For this reason, an app needs to define a storage implementation that can be used to store and retrieve a session given an ID. In a non embedded app this ID will come from a cookie however, in an embedded app this ID will come from [App Bridge](https://shopify.dev/apps/tools/app-bridge)
+Normally session information would be stored in cookies on the browser. However, due to restrictions with modern browsers we highly discourage using cookies for embedded apps. For this reason, an app needs to define a storage implementation that can be used to store and retrieve a session given an ID. In a non embedded app this ID will come from a cookie however, in an embedded app this ID will come from [App Bridge](https://shopify.dev/docs/apps/tools/app-bridge)
 
 ### Performing OAuth
 
-Next, unless you are making a private app, you need to go through OAuth as described [here](https://shopify.dev/apps/auth/oauth) to create sessions for shops using your app.
+Next, unless you are making a private app, you need to go through OAuth as described [here](https://shopify.dev/docs/apps/auth/oauth) to create sessions for shops using your app.
 The Shopify API gem tries to make this easy by providing functions to begin and complete the OAuth process. See the [Oauth doc](usage/oauth.md) for instructions on how to use these.
 
 ### Register Webhooks and a Webhook Handler

--- a/docs/usage/graphql_storefront.md
+++ b/docs/usage/graphql_storefront.md
@@ -1,8 +1,8 @@
 # Make a Storefront API call
 
-The library also allows you to send GraphQL requests to the [Shopify Storefront API](https://shopify.dev/docs/storefront-api). To do that, you can use `ShopifyAPI::Clients::Graphql::Storefront` with the current session and a `storefrontAccessToken`.
+The library also allows you to send GraphQL requests to the [Shopify Storefront API](https://shopify.dev/docs/api/storefront). To do that, you can use `ShopifyAPI::Clients::Graphql::Storefront` with the current session and a `storefrontAccessToken`.
 
-You can obtain Storefront API access tokens for both private apps and sales channels. Please read [our documentation](https://shopify.dev/docs/storefront-api/getting-started) to learn more about Storefront Access Tokens.
+You can obtain Storefront API access tokens for both private apps and sales channels. Please read [our documentation](https://shopify.dev/docs/custom-storefronts/building-with-the-storefront-api/getting-started) to learn more about Storefront Access Tokens.
 
 Below is an example of how you may query the Storefront API:
 

--- a/docs/usage/oauth.md
+++ b/docs/usage/oauth.md
@@ -3,7 +3,7 @@
 Once the library is set up for your project, you'll be able to use it to start adding functionality to your app. The first thing your app will need to do is to obtain an access token to the Admin API by performing the OAuth process.
 
 To do this, you can follow the steps below.
-For more information on authenticating a Shopify app please see the [Types of Authentication](https://shopify.dev/apps/auth#types-of-authentication) page.
+For more information on authenticating a Shopify app please see the [Types of Authentication](https://shopify.dev/docs/apps/auth#types-of-authentication) page.
 
 ## Add a route to start OAuth
 

--- a/docs/usage/rest.md
+++ b/docs/usage/rest.md
@@ -60,7 +60,7 @@ client.post({
 });
 ```
 
-_for more information on the `products` endpoint, [check out our API reference guide](https://shopify.dev/api/admin-rest/unstable/resources/product)._
+_for more information on the `products` endpoint, [check out our API reference guide](https://shopify.dev/docs/api/admin-rest/unstable/resources/product)._
 
 ### Override the `api_version`:
 
@@ -71,7 +71,7 @@ client = ShopifyAPI::Clients::Rest::Admin.new(session: session, api_version: "un
 
 ## Pagination
 
-This library also supports cursor-based pagination for REST Admin API requests. [Learn more about REST request pagination](https://shopify.dev/api/usage/pagination-rest).
+This library also supports cursor-based pagination for REST Admin API requests. [Learn more about REST request pagination](https://shopify.dev/docs/api/usage/pagination-rest).
 
 After making a request, the `next_page_info` and `prev_page_info` can be found on the response object and passed as the page_info query param in other requests.
 

--- a/shopify_api.gemspec
+++ b/shopify_api.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
     section of Shopify stores.
   HERE
   s.email = "developers@shopify.com"
-  s.homepage = "https://shopify.dev/apps"
+  s.homepage = "https://shopify.dev/docs/apps"
 
   s.metadata["allowed_push_host"] = "https://rubygems.org"
 


### PR DESCRIPTION
### WHY are these changes introduced?

Much of the api and app related content has been moved under /docs on the Shopify Dev site. This updates the links to point to the new locations.

### WHAT is this pull request doing?

See above ☝🏻 