### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ ShopifyAPI::Context.setup(
   scope: "read_orders,read_products,etc",
   session_storage: ShopifyAPI::Auth::FileSessionStorage.new, # See more details below
   is_embedded: true, # Set to true if you are building an embedded app
-  api_version: "2022-01" # The version of the API you would like to use
+  api_version: "2022-01", # The version of the API you would like to use
   is_private: false, # Set to true if you have an existing private app
 )
 ```


### PR DESCRIPTION
There's a typo in the README that leads to a syntax error when you copy the code due to a missing comma. Added the missing comma to fix this

