### PR TITLE
Fixed skipping subscription for mandatory webhooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Note: For changes to the API, see https://shopify.dev/changelog?filter=api
 
 ## Unreleased
 - [#1104](https://github.com/Shopify/shopify-api-ruby/pull/1104) Allow api version overrides.
+- [#1124](https://github.com/Shopify/shopify-api-ruby/pull/1124) Fixed skipping subscription for mandatory webhooks.
 
 ## Version 12.4.0
 

--- a/lib/shopify_api/webhooks/registry.rb
+++ b/lib/shopify_api/webhooks/registry.rb
@@ -4,7 +4,7 @@
 module ShopifyAPI
   module Webhooks
     class Registry
-      SUBSCRIPTION_NOT_REQUIRED_TOPICS = ["CUSTOMERS_DATA_REQUEST", "CUSTOMERS_REDACT", "SHOP_REDACT"]
+      SUBSCRIPTION_NOT_REQUIRED_TOPICS = T.let(["CUSTOMERS_DATA_REQUEST", "CUSTOMERS_REDACT", "SHOP_REDACT"], T::Array[String])
 
       @registry = T.let({}, T::Hash[String, Registration])
 

--- a/lib/shopify_api/webhooks/registry.rb
+++ b/lib/shopify_api/webhooks/registry.rb
@@ -4,7 +4,9 @@
 module ShopifyAPI
   module Webhooks
     class Registry
-      SUBSCRIPTION_NOT_REQUIRED_TOPICS = T.let(["CUSTOMERS_DATA_REQUEST", "CUSTOMERS_REDACT", "SHOP_REDACT"], T::Array[String])
+      SUBSCRIPTION_NOT_REQUIRED_TOPICS = T.let(
+        ["CUSTOMERS_DATA_REQUEST", "CUSTOMERS_REDACT", "SHOP_REDACT"], T::Array[String]
+      )
 
       @registry = T.let({}, T::Hash[String, Registration])
 


### PR DESCRIPTION
## Description

Fixes #1123 

This Pull Request addresses an issue that caused an error when trying to automatically subscribe to a webhook that does not require registration, such as CUSTOMERS_DATA_REQUEST, CUSTOMERS_REDACT, and SHOP_REDACT. The error occurs because the existing implementation tries to register these webhooks automatically, even though they do not require registration.

To solve the issue, we added a constant `SUBSCRIPTION_NOT_REQUIRED_TOPICS` to the ShopifyAPI::Webhooks::Registry class, which contains the list of topics that do not require registration. We also added a private method `subscription_not_required_topic?(topic)` that checks whether a given topic is in the list of topics that do not require registration. Finally, we updated the `register` and `get_webhook_id` methods to check whether a given topic requires registration before trying to subscribe to it.

## Context
This PR fixes an issue that caused an error when trying to dynamically subscribe to a webhook that does not require registration, such as CUSTOMERS_DATA_REQUEST, CUSTOMERS_REDACT, and SHOP_REDACT.

## Impact

This change improves the reliability of the ShopifyAPI::Webhooks::Registry class by preventing unnecessary registration requests for webhooks that do not require it.


## How has this been tested?

We added a new test case test_register_when_mandatory_webhook_topic to the ShopifyAPITest::Webhooks::RegistryTest class to verify that the registration succeeds for webhooks that do not require it. We also updated the existing test cases to reflect the changes in the implementation.

## Checklist:

- [x] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the project documentation.
- [x] I have added a changelog line.
