### PR TITLE
Packaging for release 12.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Note: For changes to the API, see https://shopify.dev/changelog?filter=api
 
 ## Unreleased
 
+## 12.5.0
+
 - [#1113](https://github.com/Shopify/shopify-api-ruby/pull/1113) Handle JSON::ParserError when http response is HTML and raise ShopifyAPI::Errors::HttpResponseError
 - [#1098](https://github.com/Shopify/shopify-api-ruby/pull/1098) Gracefully handle HTTP 204 repsonse bodies
 - [#1104](https://github.com/Shopify/shopify-api-ruby/pull/1104) Allow api version overrides.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify_api (12.4.0)
+    shopify_api (12.5.0)
       activesupport
       concurrent-ruby
       hash_diff
@@ -16,7 +16,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.4)
+    activesupport (7.0.4.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -26,7 +26,7 @@ GEM
     ast (2.4.2)
     byebug (11.1.3)
     coderay (1.1.3)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
     diff-lcs (1.5.0)
@@ -39,7 +39,7 @@ GEM
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     json (2.6.2)
-    jwt (2.6.0)
+    jwt (2.7.0)
     language_server-protocol (3.17.0.1)
     method_source (1.0.0)
     mini_mime (1.1.2)
@@ -47,7 +47,7 @@ GEM
     mocha (1.13.0)
     multi_xml (0.6.0)
     netrc (0.11.0)
-    oj (3.13.23)
+    oj (3.14.3)
     openssl (3.1.0)
     parallel (1.22.1)
     parser (3.1.2.1)
@@ -117,7 +117,7 @@ GEM
       thor (>= 1.2.0)
       yard-sorbet
     thor (1.2.1)
-    tzinfo (2.0.5)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.3.0)
     unparser (0.6.5)

--- a/lib/shopify_api/version.rb
+++ b/lib/shopify_api/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module ShopifyAPI
-  VERSION = "12.4.0"
+  VERSION = "12.5.0"
 end


### PR DESCRIPTION
![](https://media.tenor.com/1tgF4Y-g-_QAAAAC/maudrie-ship.gif)
Shipping `v12.5.0`!

🎩 - I created a new app with the shopify CLI and pointed to this branch and ran `bundle install`. Verified the branch version of the gem was being used. Was able to install my test app on a store and make an API call. 