### PR TITLE
JSON parseable error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Note: For changes to the API, see https://shopify.dev/changelog?filter=api
 
 ## Unreleased
 
+- [#1140](https://github.com/Shopify/shopify-api-ruby/pull/1140) ⚠️ [Breaking] Reformat Http error messages to be JSON parsable.
+
 ## 12.5.0
 
 - [#1113](https://github.com/Shopify/shopify-api-ruby/pull/1113) Handle JSON::ParserError when http response is HTML and raise ShopifyAPI::Errors::HttpResponseError


### PR DESCRIPTION
![](https://media.tenor.com/TUJ_WGkQ6pcAAAAC/dog-computer.gif)

## Description

Fixes https://github.com/Shopify/shopify-api-ruby/issues/1033

Please, include a summary of what the PR is for:
As indicated in #1033, our error messages have not been structured in a JSON serializable manner making them very difficult to parse and pass off to the front end to handle. 

## How has this been tested?

- Unit tests with the expected error data structure
- Pointed at this local branch with a sample CLI created app and verified the errors were JSON parsable:

```
irb(main):007:0> JSON.parse  "{\"errors\":{\"line_items\":[\"must have at least one line item\"]},\"error_reference\":\"If you report this error, please include this id: 6aa2cdec-9c4f-4f09-8c6d-c059564eacce.\"}"
=> {"errors"=>{"line_items"=>["must have at least one line item"]}, "error_reference"=>"If you report this error, please include this id: 6aa2cdec-9c4f-4f09-8c6d-c059564eacce."}
```
## Checklist:

- [x] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the project documentation.
- [x] I have added a changelog line.
