### PR TITLE
Fix 'taxes_included' and 'tax_shipping' type definitions

### DIFF
--- a/lib/shopify_api/rest/resources/2022_07/shop.rb
+++ b/lib/shopify_api/rest/resources/2022_07/shop.rb
@@ -64,8 +64,8 @@ module ShopifyAPI
       @setup_required = T.let(nil, T.nilable(T::Boolean))
       @shop_owner = T.let(nil, T.nilable(String))
       @source = T.let(nil, T.nilable(String))
-      @tax_shipping = T.let(nil, T.nilable(String))
-      @taxes_included = T.let(nil, T.nilable(String))
+      @tax_shipping = T.let(nil, T.nilable(T::Boolean))
+      @taxes_included = T.let(nil, T.nilable(T::Boolean))
       @timezone = T.let(nil, T.nilable(String))
       @transactional_sms_disabled = T.let(nil, T.nilable(T::Boolean))
       @updated_at = T.let(nil, T.nilable(String))
@@ -175,9 +175,9 @@ module ShopifyAPI
     attr_reader :shop_owner
     sig { returns(T.nilable(String)) }
     attr_reader :source
-    sig { returns(T.nilable(String)) }
+    sig { returns(T.nilable(T::Boolean)) }
     attr_reader :tax_shipping
-    sig { returns(T.nilable(String)) }
+    sig { returns(T.nilable(T::Boolean)) }
     attr_reader :taxes_included
     sig { returns(T.nilable(String)) }
     attr_reader :timezone

--- a/lib/shopify_api/rest/resources/2022_10/shop.rb
+++ b/lib/shopify_api/rest/resources/2022_10/shop.rb
@@ -65,8 +65,8 @@ module ShopifyAPI
       @setup_required = T.let(nil, T.nilable(T::Boolean))
       @shop_owner = T.let(nil, T.nilable(String))
       @source = T.let(nil, T.nilable(String))
-      @tax_shipping = T.let(nil, T.nilable(String))
-      @taxes_included = T.let(nil, T.nilable(String))
+      @tax_shipping = T.let(nil, T.nilable(T::Boolean))
+      @taxes_included = T.let(nil, T.nilable(T::Boolean))
       @timezone = T.let(nil, T.nilable(String))
       @transactional_sms_disabled = T.let(nil, T.nilable(T::Boolean))
       @updated_at = T.let(nil, T.nilable(String))
@@ -178,9 +178,9 @@ module ShopifyAPI
     attr_reader :shop_owner
     sig { returns(T.nilable(String)) }
     attr_reader :source
-    sig { returns(T.nilable(String)) }
+    sig { returns(T.nilable(T::Boolean)) }
     attr_reader :tax_shipping
-    sig { returns(T.nilable(String)) }
+    sig { returns(T.nilable(T::Boolean)) }
     attr_reader :taxes_included
     sig { returns(T.nilable(String)) }
     attr_reader :timezone

--- a/lib/shopify_api/rest/resources/2023_01/shop.rb
+++ b/lib/shopify_api/rest/resources/2023_01/shop.rb
@@ -65,8 +65,8 @@ module ShopifyAPI
       @setup_required = T.let(nil, T.nilable(T::Boolean))
       @shop_owner = T.let(nil, T.nilable(String))
       @source = T.let(nil, T.nilable(String))
-      @tax_shipping = T.let(nil, T.nilable(String))
-      @taxes_included = T.let(nil, T.nilable(String))
+      @tax_shipping = T.let(nil, T.nilable(T::Boolean))
+      @taxes_included = T.let(nil, T.nilable(T::Boolean))
       @timezone = T.let(nil, T.nilable(String))
       @transactional_sms_disabled = T.let(nil, T.nilable(T::Boolean))
       @updated_at = T.let(nil, T.nilable(String))
@@ -178,9 +178,9 @@ module ShopifyAPI
     attr_reader :shop_owner
     sig { returns(T.nilable(String)) }
     attr_reader :source
-    sig { returns(T.nilable(String)) }
+    sig { returns(T.nilable(T::Boolean)) }
     attr_reader :tax_shipping
-    sig { returns(T.nilable(String)) }
+    sig { returns(T.nilable(T::Boolean)) }
     attr_reader :taxes_included
     sig { returns(T.nilable(String)) }
     attr_reader :timezone

--- a/lib/shopify_api/rest/resources/2023_04/shop.rb
+++ b/lib/shopify_api/rest/resources/2023_04/shop.rb
@@ -65,8 +65,8 @@ module ShopifyAPI
       @setup_required = T.let(nil, T.nilable(T::Boolean))
       @shop_owner = T.let(nil, T.nilable(String))
       @source = T.let(nil, T.nilable(String))
-      @tax_shipping = T.let(nil, T.nilable(String))
-      @taxes_included = T.let(nil, T.nilable(String))
+      @tax_shipping = T.let(nil, T.nilable(T::Boolean))
+      @taxes_included = T.let(nil, T.nilable(T::Boolean))
       @timezone = T.let(nil, T.nilable(String))
       @transactional_sms_disabled = T.let(nil, T.nilable(T::Boolean))
       @updated_at = T.let(nil, T.nilable(String))
@@ -178,9 +178,9 @@ module ShopifyAPI
     attr_reader :shop_owner
     sig { returns(T.nilable(String)) }
     attr_reader :source
-    sig { returns(T.nilable(String)) }
+    sig { returns(T.nilable(T::Boolean)) }
     attr_reader :tax_shipping
-    sig { returns(T.nilable(String)) }
+    sig { returns(T.nilable(T::Boolean)) }
     attr_reader :taxes_included
     sig { returns(T.nilable(String)) }
     attr_reader :timezone


### PR DESCRIPTION
## Description

Fixes [#1145 ](https://github.com/Shopify/shopify-api-ruby/issues/1145)