### PR TITLE
Add support for Event topic names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Note: For changes to the API, see https://shopify.dev/changelog?filter=api
 
 - [#1140](https://github.com/Shopify/shopify-api-ruby/pull/1140) ⚠️ [Breaking] Reformat Http error messages to be JSON parsable.
 - [#1142](https://github.com/Shopify/shopify-api-ruby/issues/1142) Restore API version 2022-04, in alignment with [this](https://shopify.dev/changelog/action-required-support-for-api-version-2022-04-extended-to-june-30-2023) changelog notice.
+- [#1150](https://github.com/Shopify/shopify-api-ruby/pull/1150) [Patch] Add support for Event topic names.
 
 ## 12.5.0
 

--- a/lib/shopify_api/webhooks/registry.rb
+++ b/lib/shopify_api/webhooks/registry.rb
@@ -136,7 +136,7 @@ module ShopifyAPI
         def get_webhook_id(topic:, client:)
           fetch_id_query = <<~QUERY
             {
-              webhookSubscriptions(first: 1, topics: #{topic.gsub("/", "_").upcase}) {
+              webhookSubscriptions(first: 1, topics: #{topic.gsub(%r{/|\.}, "_").upcase}) {
                 edges {
                   node {
                     id

--- a/test/webhooks/registry_test.rb
+++ b/test/webhooks/registry_test.rb
@@ -196,6 +196,21 @@ module ShopifyAPITest
         )
       end
 
+      def test_get_webhook_id_success_for_event
+        stub_request(:post, @url)
+          .with(body: JSON.dump({ query: queries[:fetch_id_event_query], variables: nil }))
+          .to_return({ status: 200, body: JSON.dump(queries[:fetch_id_response]) })
+
+        webhook_id_response = ShopifyAPI::Webhooks::Registry.get_webhook_id(
+          topic: "domain.sub_domain.something_happened",
+          client: ShopifyAPI::Clients::Graphql::Admin.new(session: @session),
+        )
+        assert_equal(
+          queries[:fetch_id_response]["data"]["webhookSubscriptions"]["edges"][0]["node"]["id"],
+          webhook_id_response,
+        )
+      end
+
       def test_get_webhook_id_not_found
         stub_request(:post, @url)
           .with(body: JSON.dump({ query: queries[:fetch_id_query], variables: nil }))

--- a/test/webhooks/webhook_registration_queries.rb
+++ b/test/webhooks/webhook_registration_queries.rb
@@ -381,6 +381,18 @@ module ShopifyAPITest
               "message" => "some error",
             ],
           },
+          fetch_id_event_query:
+            <<~QUERY,
+              {
+                webhookSubscriptions(first: 1, topics: DOMAIN_SUB_DOMAIN_SOMETHING_HAPPENED) {
+                  edges {
+                    node {
+                      id
+                    }
+                  }
+                }
+              }
+            QUERY
           delete_query:
               <<~QUERY,
                 mutation webhookSubscription {


### PR DESCRIPTION
## Description

Allows more variety of webhook topic names.

Event topic names will allow period as a separator and these need to be translated to GraphQL valid ENUM values.


## How has this been tested?

Checking that the transformation allows strings with period separators.
 
## Checklist:

- [x] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the project documentation.
- [x] I have added a changelog line.
