### PR TITLE
Add extra type to errors for override

### DIFF
--- a/lib/shopify_api/rest/base.rb
+++ b/lib/shopify_api/rest/base.rb
@@ -21,7 +21,7 @@ module ShopifyAPI
       sig { returns(T::Hash[Symbol, T.untyped]) }
       attr_accessor :original_state
 
-      sig { returns(Rest::BaseErrors) }
+      sig { returns(T.any(Rest::BaseErrors, T.nilable(T::Hash[T.untyped, T.untyped]))) }
       attr_reader :errors
 
       sig do


### PR DESCRIPTION
## Description

`DiscountCode` has an `errors` property that overrides the same property in `base.rb`, creating a Sorbet type conflict. This commit adds the additional typing to allow the override.

## How has this been tested?

Re-running the rest wrapper tests.

## Checklist:

- [x] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the project documentation.
- not applicable ~I have added a changelog line.~
