### PR TITLE
Ignore read-only attributes when updating through REST resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Note: For changes to the API, see https://shopify.dev/changelog?filter=api
 
 ## Unreleased
 
+- [#1157](https://github.com/Shopify/shopify-api-ruby/pull/1157) Fix an issue where read-only attributes are included when saving REST resources
+
 ## 13.0.0
 
 - [#1140](https://github.com/Shopify/shopify-api-ruby/pull/1140) ⚠️ [Breaking] Reformat Http error messages to be JSON parsable.

--- a/lib/shopify_api/rest/base.rb
+++ b/lib/shopify_api/rest/base.rb
@@ -361,8 +361,12 @@ module ShopifyAPI
 
       sig { returns(T::Hash[String, String]) }
       def attributes_to_update
+        original_state_for_update = original_state.reject do |attribute, _|
+          self.class.read_only_attributes&.include?("@#{attribute}".to_sym)
+        end
+
         HashDiff::Comparison.new(
-          deep_stringify_keys(original_state),
+          deep_stringify_keys(original_state_for_update),
           deep_stringify_keys(to_hash(true)),
         ).left_diff
       end

--- a/test/clients/base_rest_resource_test.rb
+++ b/test/clients/base_rest_resource_test.rb
@@ -397,6 +397,53 @@ module ShopifyAPITest
 
         customer.save
       end
+
+      def test_put_requests_for_resource_with_read_only_attributes
+        stub_request(:get, "https://test-shop.myshopify.com/admin/api/unstable/variants/169.json")
+          .to_return(
+            status: 200,
+            body: JSON.generate(
+              {
+                "variant" => {
+                  "id" => 169,
+                  "product_id" => 116,
+                  "title" => "Default Title",
+                  "price" => "2.50",
+                  "sku" => "SKU123",
+                  "position" => 1,
+                  "inventory_policy" => "deny",
+                  "compare_at_price" => nil,
+                  "fulfillment_service" => "manual",
+                  "inventory_management" => nil,
+                  "option1" => "Default Title",
+                  "option2" => nil,
+                  "option3" => nil,
+                  "created_at" => "2023-05-10T16:37:23-04:00",
+                  "updated_at" => "2023-05-10T16:37:23-04:00",
+                  "taxable" => true,
+                  "barcode" => "0000",
+                  "grams" => 45359236093,
+                  "image_id" => nil,
+                  "weight" => 99999998.0,
+                  "weight_unit" => "lb",
+                  "inventory_item_id" => 167,
+                  "inventory_quantity" => 0,
+                  "old_inventory_quantity" => 0,
+                  "requires_shipping" => true,
+                  "admin_graphql_api_id" => "gid://shopify/ProductVariant/169",
+                },
+              },
+            ),
+          )
+
+        variant = ShopifyAPI::Variant.find(id: 169, session: @session)
+        variant.client.expects(:put).with(
+          body: { "variant" => { "barcode" => "1234" } },
+          path: "variants/169.json",
+        )
+        variant.barcode = "1234"
+        variant.save
+      end
     end
   end
 end


### PR DESCRIPTION
## Description
Follow up on the changes in this PR #1149. When a resource has read-only attributes and you attempt to call `save`, the update payload would contain an erroneous entry for the read-only attributes with the value of `HashDiff::NO_VALUE`.  

The root cause of this issue is that the `original_state` contains the read-only attributes, however the lookup of the current resource state with `to_hash(true)` strips them out. Performing a `left_diff` hash comparison then yields the resulting `HashDiff::NO_VALUE`. 

The fix I've implemented is to use a copy of the `original_state` hash with read-only attributes removed when performing the comparison to see which attributes to update.

## How has this been tested?
I've written a new unit test for the base resource and verified it failed as expected prior to implementing the fix.

## Checklist:

- [x] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the project documentation.
- [x] I have added a changelog line.
