### PR TITLE
Update CLI env variable names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Note: For changes to the API, see https://shopify.dev/changelog?filter=api
 
 ## Unreleased
 
+- [#1161](https://github.com/Shopify/shopify-api-ruby/pull/1161) [Patch] Add support for new CLI env variables.
+
 ## 13.0.0
 
 - [#1140](https://github.com/Shopify/shopify-api-ruby/pull/1140) ⚠️ [Breaking] Reformat Http error messages to be JSON parsable.

--- a/lib/shopify_api/context.rb
+++ b/lib/shopify_api/context.rb
@@ -51,7 +51,7 @@ module ShopifyAPI
         log_level: :info,
         logger: ::Logger.new($stdout),
         host_name: nil,
-        host: ENV["HOST"] || "https://#{host_name}",
+        host: ENV["SHOPIFY_APP_URL"] || ENV["HOST"] || "https://#{host_name}",
         private_shop: nil,
         user_agent_prefix: nil,
         old_api_secret_key: nil

--- a/test/context_test.rb
+++ b/test/context_test.rb
@@ -7,7 +7,7 @@ module ShopifyAPITest
   class ContextTest < Minitest::Test
     def setup
       @reader, writer = IO.pipe
-      ENV["HOST"] = "http://localhost:3000"
+      ENV["SHOPIFY_APP_URL"] = "http://localhost:3000"
 
       ShopifyAPI::Context.setup(
         api_key: "key",
@@ -107,10 +107,10 @@ module ShopifyAPITest
       end
     end
 
-    def test_with_host_name_and_no_host_env
+    def test_with_host_name_and_no_env_var
       clear_context
-      old_host = ENV["HOST"]
-      ENV["HOST"] = nil
+      old_host = ENV["SHOPIFY_APP_URL"]
+      ENV["SHOPIFY_APP_URL"] = nil
 
       ShopifyAPI::Context.setup(
         api_key: "key",
@@ -128,7 +128,32 @@ module ShopifyAPITest
       assert_equal("https", ShopifyAPI::Context.host_scheme)
       assert_equal("https://tunnel-o-security.com", ShopifyAPI::Context.host)
       assert_equal("tunnel-o-security.com", ShopifyAPI::Context.host_name)
-      ENV["HOST"] = old_host
+    ensure
+      ENV["SHOPIFY_APP_URL"] = old_host
+    end
+
+    def test_with_host_env_var
+      clear_context
+      ENV["HOST"] = "http://localhost:3000"
+
+      ShopifyAPI::Context.setup(
+        api_key: "key",
+        api_secret_key: "secret",
+        api_version: "unstable",
+        host_name: "tunnel-o-security.com",
+        scope: ["scope1", "scope2"],
+        is_private: true,
+        is_embedded: true,
+        private_shop: "privateshop.myshopify.com",
+        user_agent_prefix: "user_agent_prefix1",
+        old_api_secret_key: "old_secret",
+        log_level: :off,
+      )
+      assert_equal("http", ShopifyAPI::Context.host_scheme)
+      assert_equal("http://localhost:3000", ShopifyAPI::Context.host)
+      assert_equal("localhost", ShopifyAPI::Context.host_name)
+    ensure
+      ENV["HOST"] = nil
     end
 
     def test_send_a_warning_if_log_level_is_invalid


### PR DESCRIPTION
## Description

With https://github.com/Shopify/cli/pull/1789, the CLI will deprecate some env var names. While they will still be present so previous apps won't break, we should migrate new apps as soon as possible to the new format.

This PR adds support for the new variable names, but falls back to the current ones so it won't affect existing apps.

## Checklist:

- [x] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added a changelog line.
