### PR TITLE
v10 - Don't remove Gemfile.lock as part of CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,9 +17,6 @@ jobs:
           - 3.1
     steps:
       - uses: actions/checkout@v2
-      - name: Remove Gemfile.lock
-        run: |
-          rm -f ${GITHUB_WORKSPACE}/Gemfile.lock
       - name: Set up Ruby ${{ matrix.version }}
         uses: ruby/setup-ruby@v1
         with:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,11 +15,12 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.1)
+    activesupport (6.1.7.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)

--- a/sorbet/rbi/gems/activesupport@6.1.7.3.rbi
+++ b/sorbet/rbi/gems/activesupport@6.1.7.3.rbi
@@ -87,7 +87,6 @@ class ActiveSupport::Inflector::Inflections
 
   class << self
     def instance(locale = T.unsafe(nil)); end
-    def instance_or_fallback(locale); end
   end
 end
 
@@ -212,6 +211,8 @@ module ActiveSupport::Multibyte::Unicode
 
   def compose(codepoints); end
   def decompose(type, codepoints); end
+  def default_normalization_form; end
+  def default_normalization_form=(_); end
   def tidy_bytes(string, force = T.unsafe(nil)); end
 
   private
@@ -309,7 +310,7 @@ class Date
   def inspect; end
   def readable_inspect; end
   def to_formatted_s(format = T.unsafe(nil)); end
-  def to_fs(format = T.unsafe(nil)); end
+  def to_s(format = T.unsafe(nil)); end
   def to_time(form = T.unsafe(nil)); end
   def xmlschema; end
 end
@@ -368,8 +369,8 @@ class DateTime < ::Date
   def subsec; end
   def to_f; end
   def to_formatted_s(format = T.unsafe(nil)); end
-  def to_fs(format = T.unsafe(nil)); end
   def to_i; end
+  def to_s(format = T.unsafe(nil)); end
   def usec; end
   def utc; end
   def utc?; end
@@ -415,7 +416,6 @@ class Hash
   def as_json(options = T.unsafe(nil)); end
   def deep_merge(other_hash, &block); end
   def deep_merge!(other_hash, &block); end
-  def except(*keys); end
   def except!(*keys); end
   def extract!(*keys); end
   def slice!(*keys); end
@@ -456,6 +456,9 @@ end
 
 IO::EWOULDBLOCKWaitReadable = IO::EAGAINWaitReadable
 IO::EWOULDBLOCKWaitWritable = IO::EAGAINWaitWritable
+IO::PRIORITY = T.let(T.unsafe(nil), Integer)
+IO::READABLE = T.let(T.unsafe(nil), Integer)
+IO::WRITABLE = T.let(T.unsafe(nil), Integer)
 
 class IPAddr
   include ::Comparable
@@ -463,8 +466,11 @@ class IPAddr
   def as_json(options = T.unsafe(nil)); end
 end
 
+class LoadError < ::ScriptError
+  include ::DidYouMean::Correctable
+end
+
 class Module
-  def as_json(options = T.unsafe(nil)); end
   def cattr_accessor(*syms, instance_reader: T.unsafe(nil), instance_writer: T.unsafe(nil), instance_accessor: T.unsafe(nil), default: T.unsafe(nil), &blk); end
   def cattr_reader(*syms, instance_reader: T.unsafe(nil), instance_accessor: T.unsafe(nil), default: T.unsafe(nil), location: T.unsafe(nil)); end
   def cattr_writer(*syms, instance_writer: T.unsafe(nil), instance_accessor: T.unsafe(nil), default: T.unsafe(nil), location: T.unsafe(nil)); end
@@ -618,7 +624,6 @@ end
 
 Struct::Group = Etc::Group
 Struct::Passwd = Etc::Passwd
-Struct::Tms = Process::Tms
 
 class Symbol
   include ::Comparable
@@ -634,7 +639,7 @@ class Time
   def blank?; end
   def formatted_offset(colon = T.unsafe(nil), alternate_utc_string = T.unsafe(nil)); end
   def to_formatted_s(format = T.unsafe(nil)); end
-  def to_fs(format = T.unsafe(nil)); end
+  def to_s(format = T.unsafe(nil)); end
 end
 
 Time::DATE_FORMATS = T.let(T.unsafe(nil), Hash)


### PR DESCRIPTION
## Description
Currently the CI pipeline removes the Gemfile.lock and reinstalls the latest versions of each gem based on the target Ruby version. This step has been removed from CI on `main` in this PR: #1093 and so I'm also removing it from the v10 branch as well.

This is specifically a problem on the v10 branch since gems such as Rubocop and Sorbet have had many updates since the latest v10 release. These changes are now raising issues with the existing codebase in CI forcing us resolve the issues in this branch as well. Since the only purpose of this branch is to allow for necessary patch releases for v10, I believe it's reasonable to run CI with the same gem versions that were pinned by the Gemfile.lock at the time that v10 was originally released.

## How has this been tested?
Changes are only to the CI pipeline & one development-only dependency.

## Checklist:

- [x] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the project documentation.
- [ ] I have added a changelog line.
