### PR TITLE
Unpin zeitwerk version from 2.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Note: For changes to the API, see https://shopify.dev/changelog?filter=api
 ## Unreleased
 
 - [#1157](https://github.com/Shopify/shopify-api-ruby/pull/1157) Fix an issue where read-only attributes are included when saving REST resources
+- [#1169](https://github.com/Shopify/shopify-api-ruby/pull/1169) Unpin zeitwerk version from 2.6.5
 
 ## 13.0.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ PATH
       openssl
       securerandom
       sorbet-runtime
-      zeitwerk (~> 2.5, < 2.6.5)
+      zeitwerk (~> 2.5)
 
 GEM
   remote: https://rubygems.org/
@@ -133,7 +133,7 @@ GEM
     yard-sorbet (0.7.0)
       sorbet-runtime (>= 0.5)
       yard (>= 0.9)
-    zeitwerk (2.6.4)
+    zeitwerk (2.6.8)
 
 PLATFORMS
   arm64-darwin-21

--- a/lib/shopify_api/context.rb
+++ b/lib/shopify_api/context.rb
@@ -84,6 +84,7 @@ module ShopifyAPI
       sig { params(api_version: String).void }
       def load_rest_resources(api_version:)
         # Unload any previous instances - mostly useful for tests where we need to reset the version
+        @rest_resource_loader&.setup
         @rest_resource_loader&.unload
 
         # No resources for the unstable version

--- a/shopify_api.gemspec
+++ b/shopify_api.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("openssl")
   s.add_runtime_dependency("securerandom")
   s.add_runtime_dependency("sorbet-runtime")
-  s.add_runtime_dependency("zeitwerk", "~> 2.5", "< 2.6.5") # https://github.com/Shopify/shopify-api-ruby/issues/1058
+  s.add_runtime_dependency("zeitwerk", "~> 2.5")
 
   s.add_development_dependency("pry-byebug")
   s.add_development_dependency("rake")


### PR DESCRIPTION
## Description

Fixes #1058

Please, include a summary of what the PR is for:
- Removes the pinning of zeitwerk to version 2.6.5

## How has this been tested?

`bundle exec rake test:rest_wrappers` now runs with zeitwerk 2.6.5+

## Checklist:

- [x] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the project documentation.
- [x] I have added a changelog line.
