### PR TITLE
Fix CustomerAddress.all returning empty array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Note: For changes to the API, see https://shopify.dev/changelog?filter=api
 
 ## Unreleased
 
+- [#1192](https://github.com/Shopify/shopify-api-ruby/pull/1192) Fix no results when fetching CustomerAddress.all
+
 ## 13.1.0
 
 - [#1183](https://github.com/Shopify/shopify-api-ruby/pull/1183) Added support for API version 2023-07

--- a/lib/shopify_api/rest/resources/2023_07/customer_address.rb
+++ b/lib/shopify_api/rest/resources/2023_07/customer_address.rb
@@ -88,6 +88,13 @@ module ShopifyAPI
       end
 
       sig do
+        returns(String)
+      end
+      def json_response_body_name()
+        "addresses"
+      end
+
+      sig do
         params(
           id: T.any(Integer, String),
           customer_id: T.nilable(T.any(Integer, String)),
@@ -197,5 +204,24 @@ module ShopifyAPI
       )
     end
 
+    class << self
+      sig { params(response: Clients::HttpResponse, session: Auth::Session).returns(T::Array[ShopifyAPI::Rest::Base]) }
+      def create_instances_from_response(response:, session:)
+        objects = []
+
+        body = T.cast(response.body, T::Hash[String, T.untyped])
+
+        if body.key?('customer_addresses') || body.key?('addresses')
+          key = body.key?('customer_addresses') ? 'customer_addresses' : 'addresses'
+          body[key].each do |entry|
+            objects << create_instance(data: entry, session: session)
+          end
+        elsif body.key?('customer_address')
+          objects << create_instance(data: body['customer_address'], session: session)
+        end
+
+        objects
+      end
+    end
   end
 end

--- a/test/rest/2023_07/customer_address_test.rb
+++ b/test/rest/2023_07/customer_address_test.rb
@@ -46,12 +46,15 @@ class CustomerAddress202307Test < Test::Unit::TestCase
     )
 
     assert_requested(:get, "https://test-shop.myshopify.io/admin/api/2023-07/customers/207119551/addresses.json?limit=1")
+    assert_equal(1, response.count)
 
     response = response.first if response.respond_to?(:first)
 
     # Assert attributes are correctly typed preventing Sorbet errors downstream
     if response.respond_to?(:original_state)
       response&.original_state&.each do |key, value|
+        next if key == :default
+
         begin
           response.send(key)
         rescue TypeError => error
@@ -78,12 +81,15 @@ class CustomerAddress202307Test < Test::Unit::TestCase
     )
 
     assert_requested(:get, "https://test-shop.myshopify.io/admin/api/2023-07/customers/207119551/addresses.json")
+    assert_equal(1, response.count)
 
     response = response.first if response.respond_to?(:first)
 
     # Assert attributes are correctly typed preventing Sorbet errors downstream
     if response.respond_to?(:original_state)
       response&.original_state&.each do |key, value|
+        next if key == :default
+
         begin
           response.send(key)
         rescue TypeError => error
@@ -111,12 +117,15 @@ class CustomerAddress202307Test < Test::Unit::TestCase
     )
 
     assert_requested(:get, "https://test-shop.myshopify.io/admin/api/2023-07/customers/207119551/addresses/207119551.json")
+    assert_equal(207119551, response.id)
 
     response = response.first if response.respond_to?(:first)
 
     # Assert attributes are correctly typed preventing Sorbet errors downstream
     if response.respond_to?(:original_state)
       response&.original_state&.each do |key, value|
+        next if key == :default
+
         begin
           response.send(key)
         rescue TypeError => error


### PR DESCRIPTION
## Description

Fixes #1018, #970

When fetching CustomerAddresses, the results are returned as `addresses`. This PR adds `json_response_body_name` to the class and updates tests.

## How has this been tested?

Assertions added to count the returned results.

## Checklist:

- [x] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the project documentation.
- [x] I have added a changelog line.
