### PR TITLE
Consistent Session Cookie Value While Embedded Mode Allows Fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Note: For changes to the API, see https://shopify.dev/changelog?filter=api
 ## Unreleased
 
 - [#1183](https://github.com/Shopify/shopify-api-ruby/pull/1189) Added string array support for fields parameter in Webhook::Registry
+- [#1206](https://github.com/Shopify/shopify-api-ruby/pull/1206) Fixes the issue of empty cookie sessions when using embedded mode.
 
 ## 13.1.0
 

--- a/lib/shopify_api/auth/oauth.rb
+++ b/lib/shopify_api/auth/oauth.rb
@@ -81,17 +81,10 @@ module ShopifyAPI
 
           session = create_new_session(session_params, auth_query.shop)
 
-          cookie = if Context.embedded?
-            SessionCookie.new(
-              value: "",
-              expires: Time.now,
-            )
-          else
-            SessionCookie.new(
-              value: session.id,
-              expires: session.online? ? session.expires : nil,
-            )
-          end
+          cookie = SessionCookie.new(
+            value: session.id,
+            expires: session.online? ? session.expires : nil,
+          )
 
           { session: session, cookie: cookie }
         end


### PR DESCRIPTION
## Description

Fixes #1158

Please, include a summary of what the PR is for:
- What is the problem it is solving?
Embedded mode allows session cookie fallback, but we don't assign anything to the cookie under embedded mode.
- What is the context of these changes?
Make cookie creation consistent with session.
- What is the impact of this PR?
Make the fallback work as usual.

## How has this been tested?

Please, describe the tests that you ran to verify your changes.

## Checklist:

- [x] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have performed a self-review of my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the project documentation.
- [x] I have added a changelog line.
