### PR TITLE
Only catch jwt decode errors and preserve the error message to aid debugging

### DIFF
--- a/lib/shopify_api/auth/jwt_payload.rb
+++ b/lib/shopify_api/auth/jwt_payload.rb
@@ -75,8 +75,8 @@ module ShopifyAPI
       def decode_token(token, api_secret_key)
         JWT.decode(token, api_secret_key, true,
           { exp_leeway: JWT_EXPIRATION_LEEWAY, algorithm: "HS256" })[0]
-      rescue
-        raise ShopifyAPI::Errors::InvalidJwtTokenError, "Failed to parse session token '#{token}'"
+      rescue JWT::DecodeError => err
+        raise ShopifyAPI::Errors::InvalidJwtTokenError, "Error decoding session token: #{err.message}"
       end
     end
   end


### PR DESCRIPTION
## Description

A small change to change that preserves JWT::DecodeError error messages to aid debugging issues with JWT decoding/validation, in particular an issue where a development machine's clock is a few seconds slower than Spotify server clocks:

https://github.com/Shopify/shopify_app/issues/1214
https://github.com/kirillplatonov/shopify-hotwire-sample/issues/23


## How has this been tested?

Existing tests still pass.

## Checklist:

- [x] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have performed a self-review of my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the project documentation.
- [ ] I have added a changelog line.
