### PR TITLE
Convert json_response_body_names to array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Note: For changes to the API, see https://shopify.dev/changelog?filter=api
 ## Unreleased
 
 - [#1183](https://github.com/Shopify/shopify-api-ruby/pull/1189) Added string array support for fields parameter in Webhook::Registry
+- [1208](https://github.com/Shopify/shopify-api-ruby/pull/1208) Fix CustomerAddress and FulfillmentRequest methods
 
 ## 13.1.0
 

--- a/lib/shopify_api/rest/resources/2022_10/assigned_fulfillment_order.rb
+++ b/lib/shopify_api/rest/resources/2022_10/assigned_fulfillment_order.rb
@@ -51,10 +51,12 @@ module ShopifyAPI
 
     class << self
       sig do
-        returns(String)
+        returns(T::Array[String])
       end
-      def json_response_body_name()
-        "fulfillment_order"
+      def json_response_body_names()
+        [
+          "fulfillment_order"
+        ]
       end
 
       sig do

--- a/lib/shopify_api/rest/resources/2022_10/customer_address.rb
+++ b/lib/shopify_api/rest/resources/2022_10/customer_address.rb
@@ -88,6 +88,16 @@ module ShopifyAPI
       end
 
       sig do
+        returns(T::Array[String])
+      end
+      def json_response_body_names()
+        [
+          "customer_address",
+          "address"
+        ]
+      end
+
+      sig do
         params(
           id: T.any(Integer, String),
           customer_id: T.nilable(T.any(Integer, String)),

--- a/lib/shopify_api/rest/resources/2022_10/fulfillment_request.rb
+++ b/lib/shopify_api/rest/resources/2022_10/fulfillment_request.rb
@@ -31,6 +31,16 @@ module ShopifyAPI
     attr_reader :fulfillment_order_id
 
     class << self
+      sig do
+        returns(T::Array[String])
+      end
+      def json_response_body_names()
+        [
+          "submitted_fulfillment_order",
+          "fulfillment_order"
+        ]
+      end
+
     end
 
     sig do

--- a/lib/shopify_api/rest/resources/2022_10/order_risk.rb
+++ b/lib/shopify_api/rest/resources/2022_10/order_risk.rb
@@ -68,10 +68,12 @@ module ShopifyAPI
       end
 
       sig do
-        returns(String)
+        returns(T::Array[String])
       end
-      def json_response_body_name()
-        "risk"
+      def json_response_body_names()
+        [
+          "risk"
+        ]
       end
 
       sig do

--- a/lib/shopify_api/rest/resources/2023_01/assigned_fulfillment_order.rb
+++ b/lib/shopify_api/rest/resources/2023_01/assigned_fulfillment_order.rb
@@ -51,10 +51,12 @@ module ShopifyAPI
 
     class << self
       sig do
-        returns(String)
+        returns(T::Array[String])
       end
-      def json_response_body_name()
-        "fulfillment_order"
+      def json_response_body_names()
+        [
+          "fulfillment_order"
+        ]
       end
 
       sig do

--- a/lib/shopify_api/rest/resources/2023_01/customer_address.rb
+++ b/lib/shopify_api/rest/resources/2023_01/customer_address.rb
@@ -88,6 +88,16 @@ module ShopifyAPI
       end
 
       sig do
+        returns(T::Array[String])
+      end
+      def json_response_body_names()
+        [
+          "customer_address",
+          "address"
+        ]
+      end
+
+      sig do
         params(
           id: T.any(Integer, String),
           customer_id: T.nilable(T.any(Integer, String)),

--- a/lib/shopify_api/rest/resources/2023_01/fulfillment_request.rb
+++ b/lib/shopify_api/rest/resources/2023_01/fulfillment_request.rb
@@ -31,6 +31,16 @@ module ShopifyAPI
     attr_reader :fulfillment_order_id
 
     class << self
+      sig do
+        returns(T::Array[String])
+      end
+      def json_response_body_names()
+        [
+          "submitted_fulfillment_order",
+          "fulfillment_order"
+        ]
+      end
+
     end
 
     sig do

--- a/lib/shopify_api/rest/resources/2023_01/order_risk.rb
+++ b/lib/shopify_api/rest/resources/2023_01/order_risk.rb
@@ -68,10 +68,12 @@ module ShopifyAPI
       end
 
       sig do
-        returns(String)
+        returns(T::Array[String])
       end
-      def json_response_body_name()
-        "risk"
+      def json_response_body_names()
+        [
+          "risk"
+        ]
       end
 
       sig do

--- a/lib/shopify_api/rest/resources/2023_04/assigned_fulfillment_order.rb
+++ b/lib/shopify_api/rest/resources/2023_04/assigned_fulfillment_order.rb
@@ -51,10 +51,12 @@ module ShopifyAPI
 
     class << self
       sig do
-        returns(String)
+        returns(T::Array[String])
       end
-      def json_response_body_name()
-        "fulfillment_order"
+      def json_response_body_names()
+        [
+          "fulfillment_order"
+        ]
       end
 
       sig do

--- a/lib/shopify_api/rest/resources/2023_04/customer_address.rb
+++ b/lib/shopify_api/rest/resources/2023_04/customer_address.rb
@@ -88,6 +88,16 @@ module ShopifyAPI
       end
 
       sig do
+        returns(T::Array[String])
+      end
+      def json_response_body_names()
+        [
+          "customer_address",
+          "address"
+        ]
+      end
+
+      sig do
         params(
           id: T.any(Integer, String),
           customer_id: T.nilable(T.any(Integer, String)),

--- a/lib/shopify_api/rest/resources/2023_04/fulfillment_request.rb
+++ b/lib/shopify_api/rest/resources/2023_04/fulfillment_request.rb
@@ -31,6 +31,16 @@ module ShopifyAPI
     attr_reader :fulfillment_order_id
 
     class << self
+      sig do
+        returns(T::Array[String])
+      end
+      def json_response_body_names()
+        [
+          "submitted_fulfillment_order",
+          "fulfillment_order"
+        ]
+      end
+
     end
 
     sig do

--- a/lib/shopify_api/rest/resources/2023_04/order_risk.rb
+++ b/lib/shopify_api/rest/resources/2023_04/order_risk.rb
@@ -68,10 +68,12 @@ module ShopifyAPI
       end
 
       sig do
-        returns(String)
+        returns(T::Array[String])
       end
-      def json_response_body_name()
-        "risk"
+      def json_response_body_names()
+        [
+          "risk"
+        ]
       end
 
       sig do

--- a/lib/shopify_api/rest/resources/2023_07/assigned_fulfillment_order.rb
+++ b/lib/shopify_api/rest/resources/2023_07/assigned_fulfillment_order.rb
@@ -51,10 +51,12 @@ module ShopifyAPI
 
     class << self
       sig do
-        returns(String)
+        returns(T::Array[String])
       end
-      def json_response_body_name()
-        "fulfillment_order"
+      def json_response_body_names()
+        [
+          "fulfillment_order"
+        ]
       end
 
       sig do

--- a/lib/shopify_api/rest/resources/2023_07/customer_address.rb
+++ b/lib/shopify_api/rest/resources/2023_07/customer_address.rb
@@ -88,6 +88,16 @@ module ShopifyAPI
       end
 
       sig do
+        returns(T::Array[String])
+      end
+      def json_response_body_names()
+        [
+          "customer_address",
+          "address"
+        ]
+      end
+
+      sig do
         params(
           id: T.any(Integer, String),
           customer_id: T.nilable(T.any(Integer, String)),

--- a/lib/shopify_api/rest/resources/2023_07/fulfillment_request.rb
+++ b/lib/shopify_api/rest/resources/2023_07/fulfillment_request.rb
@@ -31,6 +31,16 @@ module ShopifyAPI
     attr_reader :fulfillment_order_id
 
     class << self
+      sig do
+        returns(T::Array[String])
+      end
+      def json_response_body_names()
+        [
+          "submitted_fulfillment_order",
+          "fulfillment_order"
+        ]
+      end
+
     end
 
     sig do

--- a/lib/shopify_api/rest/resources/2023_07/order_risk.rb
+++ b/lib/shopify_api/rest/resources/2023_07/order_risk.rb
@@ -68,10 +68,12 @@ module ShopifyAPI
       end
 
       sig do
-        returns(String)
+        returns(T::Array[String])
       end
-      def json_response_body_name()
-        "risk"
+      def json_response_body_names()
+        [
+          "risk"
+        ]
       end
 
       sig do

--- a/test/clients/base_rest_resource_test.rb
+++ b/test/clients/base_rest_resource_test.rb
@@ -182,6 +182,23 @@ module ShopifyAPITest
         refute_includes(resource.to_hash(true), "unsaveable_attribute")
       end
 
+      def test_save_allows_custom_json_body_names
+        request_body = { fake_resource: { attribute: "attribute" } }.to_json
+        response_body = { fake_resource_response: { id: 1, attribute: "attribute updated" } }.to_json
+
+        stub_request(:post, "#{@prefix}/fake_resources.json")
+          .with(body: request_body)
+          .to_return(status: 201, body: response_body)
+
+        resource = TestHelpers::FakeResource.new(session: @session)
+        resource.attribute = "attribute"
+        TestHelpers::FakeResource.stubs(:json_response_body_names).returns(["fake_resource_response"])
+
+        resource.save!
+        assert_equal(1, resource.id)
+        assert_equal("attribute updated", resource.attribute)
+      end
+
       def test_deletes_existing_resource_and_fails_on_deleting_nonexistent_resource
         resource = TestHelpers::FakeResource.new(session: @session)
         resource.id = 1

--- a/test/rest/2022_10/customer_address_test.rb
+++ b/test/rest/2022_10/customer_address_test.rb
@@ -46,20 +46,6 @@ class CustomerAddress202210Test < Test::Unit::TestCase
     )
 
     assert_requested(:get, "https://test-shop.myshopify.io/admin/api/2022-10/customers/207119551/addresses.json?limit=1")
-
-    response = response.first if response.respond_to?(:first)
-
-    # Assert attributes are correctly typed preventing Sorbet errors downstream
-    if response.respond_to?(:original_state)
-      response&.original_state&.each do |key, value|
-        begin
-          response.send(key)
-        rescue TypeError => error
-          fail TypeError.new("#{self.class}##{key} is mistyped: #{error.message}")
-        end
-        response.send(key)
-      end
-    end
   end
 
   sig do
@@ -78,20 +64,6 @@ class CustomerAddress202210Test < Test::Unit::TestCase
     )
 
     assert_requested(:get, "https://test-shop.myshopify.io/admin/api/2022-10/customers/207119551/addresses.json")
-
-    response = response.first if response.respond_to?(:first)
-
-    # Assert attributes are correctly typed preventing Sorbet errors downstream
-    if response.respond_to?(:original_state)
-      response&.original_state&.each do |key, value|
-        begin
-          response.send(key)
-        rescue TypeError => error
-          fail TypeError.new("#{self.class}##{key} is mistyped: #{error.message}")
-        end
-        response.send(key)
-      end
-    end
   end
 
   sig do
@@ -200,7 +172,7 @@ class CustomerAddress202210Test < Test::Unit::TestCase
     void
   end
   def test_6()
-    stub_request(:delete, "https://test-shop.myshopify.io/admin/api/2022-10/customers/207119551/addresses/1053317289.json")
+    stub_request(:delete, "https://test-shop.myshopify.io/admin/api/2022-10/customers/207119551/addresses/1053317286.json")
       .with(
         headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json"},
         body: {}
@@ -209,10 +181,10 @@ class CustomerAddress202210Test < Test::Unit::TestCase
 
     response = ShopifyAPI::CustomerAddress.delete(
       customer_id: 207119551,
-      id: 1053317289,
+      id: 1053317286,
     )
 
-    assert_requested(:delete, "https://test-shop.myshopify.io/admin/api/2022-10/customers/207119551/addresses/1053317289.json")
+    assert_requested(:delete, "https://test-shop.myshopify.io/admin/api/2022-10/customers/207119551/addresses/1053317286.json")
 
     response = response.first if response.respond_to?(:first)
 
@@ -233,12 +205,45 @@ class CustomerAddress202210Test < Test::Unit::TestCase
     void
   end
   def test_7()
+    stub_request(:delete, "https://test-shop.myshopify.io/admin/api/2022-10/customers/207119551/addresses/207119551.json")
+      .with(
+        headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json"},
+        body: {}
+      )
+      .to_return(status: 200, body: JSON.generate({"errors" => {"base" => ["Cannot delete the customer\u2019s default address"]}}), headers: {})
+
+    response = ShopifyAPI::CustomerAddress.delete(
+      customer_id: 207119551,
+      id: 207119551,
+    )
+
+    assert_requested(:delete, "https://test-shop.myshopify.io/admin/api/2022-10/customers/207119551/addresses/207119551.json")
+
+    response = response.first if response.respond_to?(:first)
+
+    # Assert attributes are correctly typed preventing Sorbet errors downstream
+    if response.respond_to?(:original_state)
+      response&.original_state&.each do |key, value|
+        begin
+          response.send(key)
+        rescue TypeError => error
+          fail TypeError.new("#{self.class}##{key} is mistyped: #{error.message}")
+        end
+        response.send(key)
+      end
+    end
+  end
+
+  sig do
+    void
+  end
+  def test_8()
     stub_request(:post, "https://test-shop.myshopify.io/admin/api/2022-10/customers/207119551/addresses.json")
       .with(
         headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json", "Content-Type"=>"application/json"},
         body: { "address" => hash_including({"address1" => "1 Rue des Carrieres", "address2" => "Suite 1234", "city" => "Montreal", "company" => "Fancy Co.", "first_name" => "Samuel", "last_name" => "de Champlain", "phone" => "819-555-5555", "province" => "Quebec", "country" => "Canada", "zip" => "G1R 4P5", "name" => "Samuel de Champlain", "province_code" => "QC", "country_code" => "CA", "country_name" => "Canada"}) }
       )
-      .to_return(status: 200, body: JSON.generate({"customer_address" => {"id" => 1053317288, "customer_id" => 207119551, "first_name" => "Samuel", "last_name" => "de Champlain", "company" => "Fancy Co.", "address1" => "1 Rue des Carrieres", "address2" => "Suite 1234", "city" => "Montreal", "province" => "Quebec", "country" => "Canada", "zip" => "G1R 4P5", "phone" => "819-555-5555", "name" => "Samuel de Champlain", "province_code" => "QC", "country_code" => "CA", "country_name" => "Canada", "default" => false}}), headers: {})
+      .to_return(status: 200, body: JSON.generate({"customer_address" => {"id" => 1053317287, "customer_id" => 207119551, "first_name" => "Samuel", "last_name" => "de Champlain", "company" => "Fancy Co.", "address1" => "1 Rue des Carrieres", "address2" => "Suite 1234", "city" => "Montreal", "province" => "Quebec", "country" => "Canada", "zip" => "G1R 4P5", "phone" => "819-555-5555", "name" => "Samuel de Champlain", "province_code" => "QC", "country_code" => "CA", "country_name" => "Canada", "default" => false}}), headers: {})
 
     response = customer_address = ShopifyAPI::CustomerAddress.new
     customer_address.customer_id = 207119551
@@ -278,8 +283,8 @@ class CustomerAddress202210Test < Test::Unit::TestCase
   sig do
     void
   end
-  def test_8()
-    stub_request(:put, "https://test-shop.myshopify.io/admin/api/2022-10/customers/207119551/addresses/set.json?address_ids%5B%5D=1053317287&operation=destroy")
+  def test_9()
+    stub_request(:put, "https://test-shop.myshopify.io/admin/api/2022-10/customers/207119551/addresses/set.json?address_ids%5B%5D=1053317288&operation=destroy")
       .with(
         headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json", "Content-Type"=>"application/json"},
         body: {}
@@ -289,11 +294,11 @@ class CustomerAddress202210Test < Test::Unit::TestCase
     response = customer_address = ShopifyAPI::CustomerAddress.new
     customer_address.customer_id = 207119551
     customer_address.set(
-      address_ids: ["1053317287"],
+      address_ids: ["1053317288"],
       operation: "destroy",
     )
 
-    assert_requested(:put, "https://test-shop.myshopify.io/admin/api/2022-10/customers/207119551/addresses/set.json?address_ids%5B%5D=1053317287&operation=destroy")
+    assert_requested(:put, "https://test-shop.myshopify.io/admin/api/2022-10/customers/207119551/addresses/set.json?address_ids%5B%5D=1053317288&operation=destroy")
 
     response = response.first if response.respond_to?(:first)
 
@@ -313,20 +318,20 @@ class CustomerAddress202210Test < Test::Unit::TestCase
   sig do
     void
   end
-  def test_9()
-    stub_request(:put, "https://test-shop.myshopify.io/admin/api/2022-10/customers/207119551/addresses/1053317286/default.json")
+  def test_10()
+    stub_request(:put, "https://test-shop.myshopify.io/admin/api/2022-10/customers/207119551/addresses/1053317289/default.json")
       .with(
         headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json", "Content-Type"=>"application/json"},
         body: {}
       )
-      .to_return(status: 200, body: JSON.generate({"customer_address" => {"id" => 1053317286, "customer_id" => 207119551, "first_name" => "Bob", "last_name" => "Norman", "company" => nil, "address1" => "Chestnut Street 92", "address2" => "", "city" => "Louisville", "province" => "Kentucky", "country" => "United States", "zip" => "40202", "phone" => "555-625-1199", "name" => "Bob Norman", "province_code" => "KY", "country_code" => "US", "country_name" => "United States", "default" => true}}), headers: {})
+      .to_return(status: 200, body: JSON.generate({"customer_address" => {"id" => 1053317289, "customer_id" => 207119551, "first_name" => "Bob", "last_name" => "Norman", "company" => nil, "address1" => "Chestnut Street 92", "address2" => "", "city" => "Louisville", "province" => "Kentucky", "country" => "United States", "zip" => "40202", "phone" => "555-625-1199", "name" => "Bob Norman", "province_code" => "KY", "country_code" => "US", "country_name" => "United States", "default" => true}}), headers: {})
 
     response = customer_address = ShopifyAPI::CustomerAddress.new
     customer_address.customer_id = 207119551
-    customer_address.id = 1053317286
+    customer_address.id = 1053317289
     customer_address.default
 
-    assert_requested(:put, "https://test-shop.myshopify.io/admin/api/2022-10/customers/207119551/addresses/1053317286/default.json")
+    assert_requested(:put, "https://test-shop.myshopify.io/admin/api/2022-10/customers/207119551/addresses/1053317289/default.json")
 
     response = response.first if response.respond_to?(:first)
 

--- a/test/rest/2023_01/customer_address_test.rb
+++ b/test/rest/2023_01/customer_address_test.rb
@@ -46,20 +46,6 @@ class CustomerAddress202301Test < Test::Unit::TestCase
     )
 
     assert_requested(:get, "https://test-shop.myshopify.io/admin/api/2023-01/customers/207119551/addresses.json?limit=1")
-
-    response = response.first if response.respond_to?(:first)
-
-    # Assert attributes are correctly typed preventing Sorbet errors downstream
-    if response.respond_to?(:original_state)
-      response&.original_state&.each do |key, value|
-        begin
-          response.send(key)
-        rescue TypeError => error
-          fail TypeError.new("#{self.class}##{key} is mistyped: #{error.message}")
-        end
-        response.send(key)
-      end
-    end
   end
 
   sig do
@@ -78,20 +64,6 @@ class CustomerAddress202301Test < Test::Unit::TestCase
     )
 
     assert_requested(:get, "https://test-shop.myshopify.io/admin/api/2023-01/customers/207119551/addresses.json")
-
-    response = response.first if response.respond_to?(:first)
-
-    # Assert attributes are correctly typed preventing Sorbet errors downstream
-    if response.respond_to?(:original_state)
-      response&.original_state&.each do |key, value|
-        begin
-          response.send(key)
-        rescue TypeError => error
-          fail TypeError.new("#{self.class}##{key} is mistyped: #{error.message}")
-        end
-        response.send(key)
-      end
-    end
   end
 
   sig do
@@ -200,7 +172,7 @@ class CustomerAddress202301Test < Test::Unit::TestCase
     void
   end
   def test_6()
-    stub_request(:delete, "https://test-shop.myshopify.io/admin/api/2023-01/customers/207119551/addresses/1053317289.json")
+    stub_request(:delete, "https://test-shop.myshopify.io/admin/api/2023-01/customers/207119551/addresses/1053317286.json")
       .with(
         headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json"},
         body: {}
@@ -209,10 +181,10 @@ class CustomerAddress202301Test < Test::Unit::TestCase
 
     response = ShopifyAPI::CustomerAddress.delete(
       customer_id: 207119551,
-      id: 1053317289,
+      id: 1053317286,
     )
 
-    assert_requested(:delete, "https://test-shop.myshopify.io/admin/api/2023-01/customers/207119551/addresses/1053317289.json")
+    assert_requested(:delete, "https://test-shop.myshopify.io/admin/api/2023-01/customers/207119551/addresses/1053317286.json")
 
     response = response.first if response.respond_to?(:first)
 
@@ -233,12 +205,45 @@ class CustomerAddress202301Test < Test::Unit::TestCase
     void
   end
   def test_7()
+    stub_request(:delete, "https://test-shop.myshopify.io/admin/api/2023-01/customers/207119551/addresses/207119551.json")
+      .with(
+        headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json"},
+        body: {}
+      )
+      .to_return(status: 200, body: JSON.generate({"errors" => {"base" => ["Cannot delete the customer\u2019s default address"]}}), headers: {})
+
+    response = ShopifyAPI::CustomerAddress.delete(
+      customer_id: 207119551,
+      id: 207119551,
+    )
+
+    assert_requested(:delete, "https://test-shop.myshopify.io/admin/api/2023-01/customers/207119551/addresses/207119551.json")
+
+    response = response.first if response.respond_to?(:first)
+
+    # Assert attributes are correctly typed preventing Sorbet errors downstream
+    if response.respond_to?(:original_state)
+      response&.original_state&.each do |key, value|
+        begin
+          response.send(key)
+        rescue TypeError => error
+          fail TypeError.new("#{self.class}##{key} is mistyped: #{error.message}")
+        end
+        response.send(key)
+      end
+    end
+  end
+
+  sig do
+    void
+  end
+  def test_8()
     stub_request(:post, "https://test-shop.myshopify.io/admin/api/2023-01/customers/207119551/addresses.json")
       .with(
         headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json", "Content-Type"=>"application/json"},
         body: { "address" => hash_including({"address1" => "1 Rue des Carrieres", "address2" => "Suite 1234", "city" => "Montreal", "company" => "Fancy Co.", "first_name" => "Samuel", "last_name" => "de Champlain", "phone" => "819-555-5555", "province" => "Quebec", "country" => "Canada", "zip" => "G1R 4P5", "name" => "Samuel de Champlain", "province_code" => "QC", "country_code" => "CA", "country_name" => "Canada"}) }
       )
-      .to_return(status: 200, body: JSON.generate({"customer_address" => {"id" => 1053317288, "customer_id" => 207119551, "first_name" => "Samuel", "last_name" => "de Champlain", "company" => "Fancy Co.", "address1" => "1 Rue des Carrieres", "address2" => "Suite 1234", "city" => "Montreal", "province" => "Quebec", "country" => "Canada", "zip" => "G1R 4P5", "phone" => "819-555-5555", "name" => "Samuel de Champlain", "province_code" => "QC", "country_code" => "CA", "country_name" => "Canada", "default" => false}}), headers: {})
+      .to_return(status: 200, body: JSON.generate({"customer_address" => {"id" => 1053317287, "customer_id" => 207119551, "first_name" => "Samuel", "last_name" => "de Champlain", "company" => "Fancy Co.", "address1" => "1 Rue des Carrieres", "address2" => "Suite 1234", "city" => "Montreal", "province" => "Quebec", "country" => "Canada", "zip" => "G1R 4P5", "phone" => "819-555-5555", "name" => "Samuel de Champlain", "province_code" => "QC", "country_code" => "CA", "country_name" => "Canada", "default" => false}}), headers: {})
 
     response = customer_address = ShopifyAPI::CustomerAddress.new
     customer_address.customer_id = 207119551
@@ -278,8 +283,8 @@ class CustomerAddress202301Test < Test::Unit::TestCase
   sig do
     void
   end
-  def test_8()
-    stub_request(:put, "https://test-shop.myshopify.io/admin/api/2023-01/customers/207119551/addresses/set.json?address_ids%5B%5D=1053317287&operation=destroy")
+  def test_9()
+    stub_request(:put, "https://test-shop.myshopify.io/admin/api/2023-01/customers/207119551/addresses/set.json?address_ids%5B%5D=1053317288&operation=destroy")
       .with(
         headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json", "Content-Type"=>"application/json"},
         body: {}
@@ -289,11 +294,11 @@ class CustomerAddress202301Test < Test::Unit::TestCase
     response = customer_address = ShopifyAPI::CustomerAddress.new
     customer_address.customer_id = 207119551
     customer_address.set(
-      address_ids: ["1053317287"],
+      address_ids: ["1053317288"],
       operation: "destroy",
     )
 
-    assert_requested(:put, "https://test-shop.myshopify.io/admin/api/2023-01/customers/207119551/addresses/set.json?address_ids%5B%5D=1053317287&operation=destroy")
+    assert_requested(:put, "https://test-shop.myshopify.io/admin/api/2023-01/customers/207119551/addresses/set.json?address_ids%5B%5D=1053317288&operation=destroy")
 
     response = response.first if response.respond_to?(:first)
 
@@ -313,20 +318,20 @@ class CustomerAddress202301Test < Test::Unit::TestCase
   sig do
     void
   end
-  def test_9()
-    stub_request(:put, "https://test-shop.myshopify.io/admin/api/2023-01/customers/207119551/addresses/1053317286/default.json")
+  def test_10()
+    stub_request(:put, "https://test-shop.myshopify.io/admin/api/2023-01/customers/207119551/addresses/1053317289/default.json")
       .with(
         headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json", "Content-Type"=>"application/json"},
         body: {}
       )
-      .to_return(status: 200, body: JSON.generate({"customer_address" => {"id" => 1053317286, "customer_id" => 207119551, "first_name" => "Bob", "last_name" => "Norman", "company" => nil, "address1" => "Chestnut Street 92", "address2" => "", "city" => "Louisville", "province" => "Kentucky", "country" => "United States", "zip" => "40202", "phone" => "555-625-1199", "name" => "Bob Norman", "province_code" => "KY", "country_code" => "US", "country_name" => "United States", "default" => true}}), headers: {})
+      .to_return(status: 200, body: JSON.generate({"customer_address" => {"id" => 1053317289, "customer_id" => 207119551, "first_name" => "Bob", "last_name" => "Norman", "company" => nil, "address1" => "Chestnut Street 92", "address2" => "", "city" => "Louisville", "province" => "Kentucky", "country" => "United States", "zip" => "40202", "phone" => "555-625-1199", "name" => "Bob Norman", "province_code" => "KY", "country_code" => "US", "country_name" => "United States", "default" => true}}), headers: {})
 
     response = customer_address = ShopifyAPI::CustomerAddress.new
     customer_address.customer_id = 207119551
-    customer_address.id = 1053317286
+    customer_address.id = 1053317289
     customer_address.default
 
-    assert_requested(:put, "https://test-shop.myshopify.io/admin/api/2023-01/customers/207119551/addresses/1053317286/default.json")
+    assert_requested(:put, "https://test-shop.myshopify.io/admin/api/2023-01/customers/207119551/addresses/1053317289/default.json")
 
     response = response.first if response.respond_to?(:first)
 

--- a/test/rest/2023_04/customer_address_test.rb
+++ b/test/rest/2023_04/customer_address_test.rb
@@ -46,20 +46,6 @@ class CustomerAddress202304Test < Test::Unit::TestCase
     )
 
     assert_requested(:get, "https://test-shop.myshopify.io/admin/api/2023-04/customers/207119551/addresses.json?limit=1")
-
-    response = response.first if response.respond_to?(:first)
-
-    # Assert attributes are correctly typed preventing Sorbet errors downstream
-    if response.respond_to?(:original_state)
-      response&.original_state&.each do |key, value|
-        begin
-          response.send(key)
-        rescue TypeError => error
-          fail TypeError.new("#{self.class}##{key} is mistyped: #{error.message}")
-        end
-        response.send(key)
-      end
-    end
   end
 
   sig do
@@ -78,20 +64,6 @@ class CustomerAddress202304Test < Test::Unit::TestCase
     )
 
     assert_requested(:get, "https://test-shop.myshopify.io/admin/api/2023-04/customers/207119551/addresses.json")
-
-    response = response.first if response.respond_to?(:first)
-
-    # Assert attributes are correctly typed preventing Sorbet errors downstream
-    if response.respond_to?(:original_state)
-      response&.original_state&.each do |key, value|
-        begin
-          response.send(key)
-        rescue TypeError => error
-          fail TypeError.new("#{self.class}##{key} is mistyped: #{error.message}")
-        end
-        response.send(key)
-      end
-    end
   end
 
   sig do
@@ -200,7 +172,7 @@ class CustomerAddress202304Test < Test::Unit::TestCase
     void
   end
   def test_6()
-    stub_request(:delete, "https://test-shop.myshopify.io/admin/api/2023-04/customers/207119551/addresses/1053317289.json")
+    stub_request(:delete, "https://test-shop.myshopify.io/admin/api/2023-04/customers/207119551/addresses/1053317286.json")
       .with(
         headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json"},
         body: {}
@@ -209,10 +181,10 @@ class CustomerAddress202304Test < Test::Unit::TestCase
 
     response = ShopifyAPI::CustomerAddress.delete(
       customer_id: 207119551,
-      id: 1053317289,
+      id: 1053317286,
     )
 
-    assert_requested(:delete, "https://test-shop.myshopify.io/admin/api/2023-04/customers/207119551/addresses/1053317289.json")
+    assert_requested(:delete, "https://test-shop.myshopify.io/admin/api/2023-04/customers/207119551/addresses/1053317286.json")
 
     response = response.first if response.respond_to?(:first)
 
@@ -233,12 +205,45 @@ class CustomerAddress202304Test < Test::Unit::TestCase
     void
   end
   def test_7()
+    stub_request(:delete, "https://test-shop.myshopify.io/admin/api/2023-04/customers/207119551/addresses/207119551.json")
+      .with(
+        headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json"},
+        body: {}
+      )
+      .to_return(status: 200, body: JSON.generate({"errors" => {"base" => ["Cannot delete the customer\u2019s default address"]}}), headers: {})
+
+    response = ShopifyAPI::CustomerAddress.delete(
+      customer_id: 207119551,
+      id: 207119551,
+    )
+
+    assert_requested(:delete, "https://test-shop.myshopify.io/admin/api/2023-04/customers/207119551/addresses/207119551.json")
+
+    response = response.first if response.respond_to?(:first)
+
+    # Assert attributes are correctly typed preventing Sorbet errors downstream
+    if response.respond_to?(:original_state)
+      response&.original_state&.each do |key, value|
+        begin
+          response.send(key)
+        rescue TypeError => error
+          fail TypeError.new("#{self.class}##{key} is mistyped: #{error.message}")
+        end
+        response.send(key)
+      end
+    end
+  end
+
+  sig do
+    void
+  end
+  def test_8()
     stub_request(:post, "https://test-shop.myshopify.io/admin/api/2023-04/customers/207119551/addresses.json")
       .with(
         headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json", "Content-Type"=>"application/json"},
         body: { "address" => hash_including({"address1" => "1 Rue des Carrieres", "address2" => "Suite 1234", "city" => "Montreal", "company" => "Fancy Co.", "first_name" => "Samuel", "last_name" => "de Champlain", "phone" => "819-555-5555", "province" => "Quebec", "country" => "Canada", "zip" => "G1R 4P5", "name" => "Samuel de Champlain", "province_code" => "QC", "country_code" => "CA", "country_name" => "Canada"}) }
       )
-      .to_return(status: 200, body: JSON.generate({"customer_address" => {"id" => 1053317288, "customer_id" => 207119551, "first_name" => "Samuel", "last_name" => "de Champlain", "company" => "Fancy Co.", "address1" => "1 Rue des Carrieres", "address2" => "Suite 1234", "city" => "Montreal", "province" => "Quebec", "country" => "Canada", "zip" => "G1R 4P5", "phone" => "819-555-5555", "name" => "Samuel de Champlain", "province_code" => "QC", "country_code" => "CA", "country_name" => "Canada", "default" => false}}), headers: {})
+      .to_return(status: 200, body: JSON.generate({"customer_address" => {"id" => 1053317287, "customer_id" => 207119551, "first_name" => "Samuel", "last_name" => "de Champlain", "company" => "Fancy Co.", "address1" => "1 Rue des Carrieres", "address2" => "Suite 1234", "city" => "Montreal", "province" => "Quebec", "country" => "Canada", "zip" => "G1R 4P5", "phone" => "819-555-5555", "name" => "Samuel de Champlain", "province_code" => "QC", "country_code" => "CA", "country_name" => "Canada", "default" => false}}), headers: {})
 
     response = customer_address = ShopifyAPI::CustomerAddress.new
     customer_address.customer_id = 207119551
@@ -278,8 +283,8 @@ class CustomerAddress202304Test < Test::Unit::TestCase
   sig do
     void
   end
-  def test_8()
-    stub_request(:put, "https://test-shop.myshopify.io/admin/api/2023-04/customers/207119551/addresses/set.json?address_ids%5B%5D=1053317287&operation=destroy")
+  def test_9()
+    stub_request(:put, "https://test-shop.myshopify.io/admin/api/2023-04/customers/207119551/addresses/set.json?address_ids%5B%5D=1053317288&operation=destroy")
       .with(
         headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json", "Content-Type"=>"application/json"},
         body: {}
@@ -289,11 +294,11 @@ class CustomerAddress202304Test < Test::Unit::TestCase
     response = customer_address = ShopifyAPI::CustomerAddress.new
     customer_address.customer_id = 207119551
     customer_address.set(
-      address_ids: ["1053317287"],
+      address_ids: ["1053317288"],
       operation: "destroy",
     )
 
-    assert_requested(:put, "https://test-shop.myshopify.io/admin/api/2023-04/customers/207119551/addresses/set.json?address_ids%5B%5D=1053317287&operation=destroy")
+    assert_requested(:put, "https://test-shop.myshopify.io/admin/api/2023-04/customers/207119551/addresses/set.json?address_ids%5B%5D=1053317288&operation=destroy")
 
     response = response.first if response.respond_to?(:first)
 
@@ -313,20 +318,20 @@ class CustomerAddress202304Test < Test::Unit::TestCase
   sig do
     void
   end
-  def test_9()
-    stub_request(:put, "https://test-shop.myshopify.io/admin/api/2023-04/customers/207119551/addresses/1053317286/default.json")
+  def test_10()
+    stub_request(:put, "https://test-shop.myshopify.io/admin/api/2023-04/customers/207119551/addresses/1053317289/default.json")
       .with(
         headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json", "Content-Type"=>"application/json"},
         body: {}
       )
-      .to_return(status: 200, body: JSON.generate({"customer_address" => {"id" => 1053317286, "customer_id" => 207119551, "first_name" => "Bob", "last_name" => "Norman", "company" => nil, "address1" => "Chestnut Street 92", "address2" => "", "city" => "Louisville", "province" => "Kentucky", "country" => "United States", "zip" => "40202", "phone" => "555-625-1199", "name" => "Bob Norman", "province_code" => "KY", "country_code" => "US", "country_name" => "United States", "default" => true}}), headers: {})
+      .to_return(status: 200, body: JSON.generate({"customer_address" => {"id" => 1053317289, "customer_id" => 207119551, "first_name" => "Bob", "last_name" => "Norman", "company" => nil, "address1" => "Chestnut Street 92", "address2" => "", "city" => "Louisville", "province" => "Kentucky", "country" => "United States", "zip" => "40202", "phone" => "555-625-1199", "name" => "Bob Norman", "province_code" => "KY", "country_code" => "US", "country_name" => "United States", "default" => true}}), headers: {})
 
     response = customer_address = ShopifyAPI::CustomerAddress.new
     customer_address.customer_id = 207119551
-    customer_address.id = 1053317286
+    customer_address.id = 1053317289
     customer_address.default
 
-    assert_requested(:put, "https://test-shop.myshopify.io/admin/api/2023-04/customers/207119551/addresses/1053317286/default.json")
+    assert_requested(:put, "https://test-shop.myshopify.io/admin/api/2023-04/customers/207119551/addresses/1053317289/default.json")
 
     response = response.first if response.respond_to?(:first)
 

--- a/test/rest/2023_07/customer_address_test.rb
+++ b/test/rest/2023_07/customer_address_test.rb
@@ -46,20 +46,6 @@ class CustomerAddress202307Test < Test::Unit::TestCase
     )
 
     assert_requested(:get, "https://test-shop.myshopify.io/admin/api/2023-07/customers/207119551/addresses.json?limit=1")
-
-    response = response.first if response.respond_to?(:first)
-
-    # Assert attributes are correctly typed preventing Sorbet errors downstream
-    if response.respond_to?(:original_state)
-      response&.original_state&.each do |key, value|
-        begin
-          response.send(key)
-        rescue TypeError => error
-          fail TypeError.new("#{self.class}##{key} is mistyped: #{error.message}")
-        end
-        response.send(key)
-      end
-    end
   end
 
   sig do
@@ -78,20 +64,6 @@ class CustomerAddress202307Test < Test::Unit::TestCase
     )
 
     assert_requested(:get, "https://test-shop.myshopify.io/admin/api/2023-07/customers/207119551/addresses.json")
-
-    response = response.first if response.respond_to?(:first)
-
-    # Assert attributes are correctly typed preventing Sorbet errors downstream
-    if response.respond_to?(:original_state)
-      response&.original_state&.each do |key, value|
-        begin
-          response.send(key)
-        rescue TypeError => error
-          fail TypeError.new("#{self.class}##{key} is mistyped: #{error.message}")
-        end
-        response.send(key)
-      end
-    end
   end
 
   sig do
@@ -200,7 +172,7 @@ class CustomerAddress202307Test < Test::Unit::TestCase
     void
   end
   def test_6()
-    stub_request(:delete, "https://test-shop.myshopify.io/admin/api/2023-07/customers/207119551/addresses/1053317289.json")
+    stub_request(:delete, "https://test-shop.myshopify.io/admin/api/2023-07/customers/207119551/addresses/1053317286.json")
       .with(
         headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json"},
         body: {}
@@ -209,10 +181,10 @@ class CustomerAddress202307Test < Test::Unit::TestCase
 
     response = ShopifyAPI::CustomerAddress.delete(
       customer_id: 207119551,
-      id: 1053317289,
+      id: 1053317286,
     )
 
-    assert_requested(:delete, "https://test-shop.myshopify.io/admin/api/2023-07/customers/207119551/addresses/1053317289.json")
+    assert_requested(:delete, "https://test-shop.myshopify.io/admin/api/2023-07/customers/207119551/addresses/1053317286.json")
 
     response = response.first if response.respond_to?(:first)
 
@@ -233,12 +205,45 @@ class CustomerAddress202307Test < Test::Unit::TestCase
     void
   end
   def test_7()
+    stub_request(:delete, "https://test-shop.myshopify.io/admin/api/2023-07/customers/207119551/addresses/207119551.json")
+      .with(
+        headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json"},
+        body: {}
+      )
+      .to_return(status: 200, body: JSON.generate({"errors" => {"base" => ["Cannot delete the customer\u2019s default address"]}}), headers: {})
+
+    response = ShopifyAPI::CustomerAddress.delete(
+      customer_id: 207119551,
+      id: 207119551,
+    )
+
+    assert_requested(:delete, "https://test-shop.myshopify.io/admin/api/2023-07/customers/207119551/addresses/207119551.json")
+
+    response = response.first if response.respond_to?(:first)
+
+    # Assert attributes are correctly typed preventing Sorbet errors downstream
+    if response.respond_to?(:original_state)
+      response&.original_state&.each do |key, value|
+        begin
+          response.send(key)
+        rescue TypeError => error
+          fail TypeError.new("#{self.class}##{key} is mistyped: #{error.message}")
+        end
+        response.send(key)
+      end
+    end
+  end
+
+  sig do
+    void
+  end
+  def test_8()
     stub_request(:post, "https://test-shop.myshopify.io/admin/api/2023-07/customers/207119551/addresses.json")
       .with(
         headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json", "Content-Type"=>"application/json"},
         body: { "address" => hash_including({"address1" => "1 Rue des Carrieres", "address2" => "Suite 1234", "city" => "Montreal", "company" => "Fancy Co.", "first_name" => "Samuel", "last_name" => "de Champlain", "phone" => "819-555-5555", "province" => "Quebec", "country" => "Canada", "zip" => "G1R 4P5", "name" => "Samuel de Champlain", "province_code" => "QC", "country_code" => "CA", "country_name" => "Canada"}) }
       )
-      .to_return(status: 200, body: JSON.generate({"customer_address" => {"id" => 1053317288, "customer_id" => 207119551, "first_name" => "Samuel", "last_name" => "de Champlain", "company" => "Fancy Co.", "address1" => "1 Rue des Carrieres", "address2" => "Suite 1234", "city" => "Montreal", "province" => "Quebec", "country" => "Canada", "zip" => "G1R 4P5", "phone" => "819-555-5555", "name" => "Samuel de Champlain", "province_code" => "QC", "country_code" => "CA", "country_name" => "Canada", "default" => false}}), headers: {})
+      .to_return(status: 200, body: JSON.generate({"customer_address" => {"id" => 1053317287, "customer_id" => 207119551, "first_name" => "Samuel", "last_name" => "de Champlain", "company" => "Fancy Co.", "address1" => "1 Rue des Carrieres", "address2" => "Suite 1234", "city" => "Montreal", "province" => "Quebec", "country" => "Canada", "zip" => "G1R 4P5", "phone" => "819-555-5555", "name" => "Samuel de Champlain", "province_code" => "QC", "country_code" => "CA", "country_name" => "Canada", "default" => false}}), headers: {})
 
     response = customer_address = ShopifyAPI::CustomerAddress.new
     customer_address.customer_id = 207119551
@@ -278,8 +283,8 @@ class CustomerAddress202307Test < Test::Unit::TestCase
   sig do
     void
   end
-  def test_8()
-    stub_request(:put, "https://test-shop.myshopify.io/admin/api/2023-07/customers/207119551/addresses/set.json?address_ids%5B%5D=1053317287&operation=destroy")
+  def test_9()
+    stub_request(:put, "https://test-shop.myshopify.io/admin/api/2023-07/customers/207119551/addresses/set.json?address_ids%5B%5D=1053317288&operation=destroy")
       .with(
         headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json", "Content-Type"=>"application/json"},
         body: {}
@@ -289,11 +294,11 @@ class CustomerAddress202307Test < Test::Unit::TestCase
     response = customer_address = ShopifyAPI::CustomerAddress.new
     customer_address.customer_id = 207119551
     customer_address.set(
-      address_ids: ["1053317287"],
+      address_ids: ["1053317288"],
       operation: "destroy",
     )
 
-    assert_requested(:put, "https://test-shop.myshopify.io/admin/api/2023-07/customers/207119551/addresses/set.json?address_ids%5B%5D=1053317287&operation=destroy")
+    assert_requested(:put, "https://test-shop.myshopify.io/admin/api/2023-07/customers/207119551/addresses/set.json?address_ids%5B%5D=1053317288&operation=destroy")
 
     response = response.first if response.respond_to?(:first)
 
@@ -313,20 +318,20 @@ class CustomerAddress202307Test < Test::Unit::TestCase
   sig do
     void
   end
-  def test_9()
-    stub_request(:put, "https://test-shop.myshopify.io/admin/api/2023-07/customers/207119551/addresses/1053317286/default.json")
+  def test_10()
+    stub_request(:put, "https://test-shop.myshopify.io/admin/api/2023-07/customers/207119551/addresses/1053317289/default.json")
       .with(
         headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json", "Content-Type"=>"application/json"},
         body: {}
       )
-      .to_return(status: 200, body: JSON.generate({"customer_address" => {"id" => 1053317286, "customer_id" => 207119551, "first_name" => "Bob", "last_name" => "Norman", "company" => nil, "address1" => "Chestnut Street 92", "address2" => "", "city" => "Louisville", "province" => "Kentucky", "country" => "United States", "zip" => "40202", "phone" => "555-625-1199", "name" => "Bob Norman", "province_code" => "KY", "country_code" => "US", "country_name" => "United States", "default" => true}}), headers: {})
+      .to_return(status: 200, body: JSON.generate({"customer_address" => {"id" => 1053317289, "customer_id" => 207119551, "first_name" => "Bob", "last_name" => "Norman", "company" => nil, "address1" => "Chestnut Street 92", "address2" => "", "city" => "Louisville", "province" => "Kentucky", "country" => "United States", "zip" => "40202", "phone" => "555-625-1199", "name" => "Bob Norman", "province_code" => "KY", "country_code" => "US", "country_name" => "United States", "default" => true}}), headers: {})
 
     response = customer_address = ShopifyAPI::CustomerAddress.new
     customer_address.customer_id = 207119551
-    customer_address.id = 1053317286
+    customer_address.id = 1053317289
     customer_address.default
 
-    assert_requested(:put, "https://test-shop.myshopify.io/admin/api/2023-07/customers/207119551/addresses/1053317286/default.json")
+    assert_requested(:put, "https://test-shop.myshopify.io/admin/api/2023-07/customers/207119551/addresses/1053317289/default.json")
 
     response = response.first if response.respond_to?(:first)
 


### PR DESCRIPTION
## Description

Fixes https://github.com/Shopify/shopify-api-ruby/issues/1018
Fixes https://github.com/Shopify/shopify-api-ruby/issues/1190

Allowing multiple response body names to be passed in so we can check and build a response based on what key matches the for the class

## How has this been tested?
Created a fresh app and pre-populated test store and made sure we can create a fulfillment request without sorbet error
Get a response back from CustomerAddress.all

## Checklist:

- [x] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] ~I have updated the project documentation.~
- [ ] I have added a changelog line.
