### PR TITLE
Make logger untyped

### DIFF
--- a/lib/shopify_api/context.rb
+++ b/lib/shopify_api/context.rb
@@ -12,7 +12,9 @@ module ShopifyAPI
     @is_private = T.let(false, T::Boolean)
     @private_shop = T.let(nil, T.nilable(String))
     @is_embedded = T.let(true, T::Boolean)
-    @logger = T.let(::Logger.new($stdout), ::Logger)
+    # Logger can either be a Logger or an ActiveSupport::BroadcastLogger, which is new in Rails 7.1.0. To avoid adding a
+    # dependency Active Support >= 7.1.0, we go with T.untyped
+    @logger = T.let(::Logger.new($stdout), T.untyped)
     @log_level = T.let(:info, Symbol)
     @notified_missing_resources_folder = T.let({}, T::Hash[String, T::Boolean])
     @active_session = T.let(Concurrent::ThreadLocalVar.new { nil }, T.nilable(Concurrent::ThreadLocalVar))
@@ -33,7 +35,7 @@ module ShopifyAPI
           is_private: T::Boolean,
           is_embedded: T::Boolean,
           log_level: T.any(String, Symbol),
-          logger: ::Logger,
+          logger: T.untyped,
           host_name: T.nilable(String),
           host: T.nilable(String),
           private_shop: T.nilable(String),
@@ -116,7 +118,7 @@ module ShopifyAPI
       sig { returns(Auth::AuthScopes) }
       attr_reader :scope
 
-      sig { returns(::Logger) }
+      sig { returns(T.untyped) }
       attr_reader :logger
 
       sig { returns(Symbol) }


### PR DESCRIPTION
## Description

In [this commit](https://github.com/rails/rails/commit/1fbd812c47f7ba840390942e56d9b2ebbc260901) which is part of Rails 7.1, the default logger changed from `Logger` to the new `BroadcastLogger`.

This change causes a `sorbet-runtime` error because `BroadcastLogger` does not inherit from `Logger` and therefore doesn't match the expected type in the signature for the `setup` method.

This ends up being a weird issue. The `BroadcastLogger` class was designed to match the same interface as `Logger`. However, we can't use a Sorbet interface in this case. For an interface to work, it needs to be included in the actual runtime - and Rails won't include a Sorbet construct in the codebase.

Even using `T.any(Logger, Rails::BroadcastLogger)` wouldn't work properly. This gem has a dependency on Active Support, but using the new `BroadcastLogger` would create a dependency on Active Support `>= 7.1.0`, which is probably too new for all consumers of this gem.

Therefore, despite the unfortunate loss in type safety, I think the way forward is to set `logger` to `T.untyped` so that we can accept both `Logger` and `BroadcastLogger` without creating a dependency on Rails.

This unblocks Rails 7.1 upgrades.

## How has this been tested?

Just ran `bundle exec rake test`.

## Checklist:

- [x] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have performed a self-review of my own code.
- [ ] N/A. I have added tests that prove my fix is effective or that my feature works.
- [ ] N/A. I have updated the project documentation.
- [ ] N/A. I have added a changelog line.
