### PR TITLE
Remove `ruby-lsp` from dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,7 +40,6 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.6.2)
     jwt (2.7.1)
-    language_server-protocol (3.17.0.1)
     method_source (1.0.0)
     mini_mime (1.1.5)
     minitest (5.15.0)
@@ -50,9 +49,9 @@ GEM
     oj (3.16.0)
     openssl (3.1.0)
     parallel (1.22.1)
-    parser (3.1.2.1)
+    parser (3.2.2.4)
       ast (~> 2.4.1)
-    prettier_print (0.1.0)
+      racc
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -60,6 +59,7 @@ GEM
       byebug (~> 11.0)
       pry (>= 0.13, < 0.15)
     public_suffix (4.0.6)
+    racc (1.7.1)
     rainbow (3.1.1)
     rake (13.0.6)
     rbi (0.0.15)
@@ -85,10 +85,6 @@ GEM
       rubocop (~> 1.35)
     rubocop-sorbet (0.6.11)
       rubocop (>= 0.90.0)
-    ruby-lsp (0.3.2)
-      language_server-protocol (~> 3.17.0)
-      sorbet-runtime
-      syntax_tree (>= 3.4)
     ruby-progressbar (1.11.0)
     securerandom (0.2.2)
     sorbet (0.5.10438)
@@ -104,8 +100,6 @@ GEM
       sorbet (>= 0.5.9204)
       sorbet-runtime (>= 0.5.9204)
       thor (>= 0.19.2)
-    syntax_tree (3.6.1)
-      prettier_print
     tapioca (0.10.2)
       bundler (>= 1.17.3)
       netrc (>= 0.11.0)
@@ -149,7 +143,6 @@ DEPENDENCIES
   rubocop
   rubocop-shopify
   rubocop-sorbet
-  ruby-lsp
   shopify_api!
   sorbet
   tapioca

--- a/shopify_api.gemspec
+++ b/shopify_api.gemspec
@@ -48,7 +48,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency("rubocop")
   s.add_development_dependency("rubocop-shopify")
   s.add_development_dependency("rubocop-sorbet")
-  s.add_development_dependency("ruby-lsp")
   s.add_development_dependency("sorbet")
   s.add_development_dependency("tapioca")
 end


### PR DESCRIPTION
## Description

When I was working on #1226, I noticed that this gem still has the `ruby-lsp` as a development dependency.

We made changes so that the server can auto-update itself and it's no longer recommended to leave it in the gemspec or Gemfile.

This PR just removes the `ruby-lsp` from the gemspec so that people working on it get auto-updates. I also upgraded the `parser` gem because there's a bug that prevents the LSP from starting in older versions.

These are only development changes.

## How has this been tested?

Opened VS Code on the project, verified that I got the latest Ruby LSP server version running.

## Checklist:

- [x] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have performed a self-review of my own code.
- [x] N/A I have added tests that prove my fix is effective or that my feature works.
- [x] N/A I have updated the project documentation.
- [x] N/A I have added a changelog line.
