### PR TITLE
Add OpenSSL install to the GH pipelines

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,9 +17,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby ${{ matrix.version }}
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@v2
         with:
           ruby-version: ${{ matrix.version }}
+          bundler-cache: true
+      - name: Install OpenSSL
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev
       - name: Run Bundle Commands
         run: |
           bundle config set --with docs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby ${{ matrix.version }}
-        uses: ruby/setup-ruby@v2
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.version }}
-          bundler-cache: true
       - name: Install OpenSSL
         run: |
           sudo apt-get update


### PR DESCRIPTION
![](https://media.tenor.com/OBF-dgsfnZQAAAAC/patrick-open.gif)

Looking at the pipeline failures we've been seeing for PRs, the consistent theme was HMAC validation tests failing due to OpenSSL. After installing OpenSSL as part of the setup process, I ran the pipelines twice and saw two successful runs.