### PR TITLE
skip mandatory webhook topics during registration/unregistration

### DIFF
--- a/test/webhooks/registry_test.rb
+++ b/test/webhooks/registry_test.rb
@@ -262,6 +262,24 @@ module ShopifyAPITest
         assert_equal("Failed to fetch webhook from Shopify: some error", exception.message)
       end
 
+      def test_registrations_to_mandatory_topics_are_ignored
+        ShopifyAPI::Webhooks::Registry.clear
+
+        ShopifyAPI::Webhooks::Registry::MANDATORY_TOPICS.each do |topic|
+          ShopifyAPI::Webhooks::Registry.add_registration(
+            topic: topic,
+            delivery_method: :http,
+            path: "some_path_under_the_rainbow",
+            handler: TestHelpers::FakeWebhookHandler.new(
+              lambda do |topic, shop, body|
+              end,
+            ),
+          )
+        end
+
+        assert_empty(ShopifyAPI::Webhooks::Registry.topics_in_registry)
+      end
+
       private
 
       def do_registration_test(delivery_method, path, fields: nil, metafield_namespaces: nil)
@@ -359,6 +377,7 @@ module ShopifyAPITest
         )
         end
       end
+
     end
   end
 end

--- a/test/webhooks/registry_test.rb
+++ b/test/webhooks/registry_test.rb
@@ -206,6 +206,17 @@ module ShopifyAPITest
         assert_equal("Failed to delete webhook from Shopify: some error", exception.message)
       end
 
+      def test_unregister_to_mandatory_topics_are_skipped
+        ShopifyAPI::Clients::Graphql::Admin.expects(:new).never
+
+        ShopifyAPI::Webhooks::Registry::MANDATORY_TOPICS.each do |topic|
+          ShopifyAPI::Webhooks::Registry.unregister(
+            topic: topic,
+            session: @session,
+          )
+        end
+      end
+
       def test_get_webhook_id_success
         stub_request(:post, @url)
           .with(body: JSON.dump({ query: queries[:fetch_id_query], variables: nil }))
@@ -265,6 +276,8 @@ module ShopifyAPITest
       def test_registrations_to_mandatory_topics_are_ignored
         ShopifyAPI::Webhooks::Registry.clear
 
+        ShopifyAPI::Webhooks::Registrations::Http.expects(:new).never
+
         ShopifyAPI::Webhooks::Registry::MANDATORY_TOPICS.each do |topic|
           ShopifyAPI::Webhooks::Registry.add_registration(
             topic: topic,
@@ -276,8 +289,6 @@ module ShopifyAPITest
             ),
           )
         end
-
-        assert_empty(ShopifyAPI::Webhooks::Registry.topics_in_registry)
       end
 
       private


### PR DESCRIPTION

## Description

Friction with mandatory webhooks was identified in the [shopify app gem](https://github.com/Shopify/shopify_app/issues/1719). Since Mandatory webhooks aren't subscribed to via API, we need to gracefully skip them during registrations without breaking handlers. 

This skips registration/unregistration for [mandatory topics that are managed in the partner dashboard](https://shopify.dev/docs/apps/webhooks/configuration/mandatory-webhooks)

## How has this been tested?

Unit tests within this library. I've also created a new app using our [ruby app template](https://github.com/Shopify/shopify-app-template-ruby) pointing to this branch and [my fix to the app gem's branch](https://github.com/Shopify/shopify_app/pull/1743) to verify I could recreate webhook without error.

## Checklist:

- [ ] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x ] I have performed a self-review of my own code.
- [ x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the project documentation.
- [ ] I have added a changelog line.
