### PR TITLE
Add api_host to ShopifyAPI::Context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Note: For changes to the API, see https://shopify.dev/changelog?filter=api
 
 ## Unreleased
+- []() Add `api_host` to `ShopifyAPI::Context.setup`, allowing the API host to be overridden in `ShopifyAPI::Clients::HttpClient`
 - [#1237](https://github.com/Shopify/shopify-api-ruby/pull/1237) Skip mandatory webhook topic registration/unregistrations
 
 ## 13.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Note: For changes to the API, see https://shopify.dev/changelog?filter=api
 
 ## Unreleased
-- [#1241](https://github.com/Shopify/shopify-api-ruby/pull/1241) Add `api_host` to `ShopifyAPI::Context.setup`, allowing the API host to be overridden in `ShopifyAPI::Clients::HttpClient`
+- [#1241](https://github.com/Shopify/shopify-api-ruby/pull/1241) Add `api_host` to `ShopifyAPI::Context.setup`, allowing the API host to be overridden in `ShopifyAPI::Clients::HttpClient`. This context option is intended for internal Shopify use only. 
 - [#1237](https://github.com/Shopify/shopify-api-ruby/pull/1237) Skip mandatory webhook topic registration/unregistrations
 
 ## 13.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Note: For changes to the API, see https://shopify.dev/changelog?filter=api
 
 ## Unreleased
-- []() Add `api_host` to `ShopifyAPI::Context.setup`, allowing the API host to be overridden in `ShopifyAPI::Clients::HttpClient`
+- [#1241](https://github.com/Shopify/shopify-api-ruby/pull/1241) Add `api_host` to `ShopifyAPI::Context.setup`, allowing the API host to be overridden in `ShopifyAPI::Clients::HttpClient`
 - [#1237](https://github.com/Shopify/shopify-api-ruby/pull/1237) Skip mandatory webhook topic registration/unregistrations
 
 ## 13.2.0

--- a/lib/shopify_api/clients/http_client.rb
+++ b/lib/shopify_api/clients/http_client.rb
@@ -13,7 +13,9 @@ module ShopifyAPI
         session ||= Context.active_session
         raise Errors::NoActiveSessionError, "No passed or active session" unless session
 
-        @base_uri = T.let("https://#{session.shop}", String)
+        api_host = Context.api_host
+
+        @base_uri = T.let("https://#{api_host || session.shop}", String)
         @base_uri_and_path = T.let("#{@base_uri}#{base_path}", String)
 
         user_agent_prefix = Context.user_agent_prefix.nil? ? "" : "#{Context.user_agent_prefix} | "
@@ -22,6 +24,8 @@ module ShopifyAPI
           "User-Agent": "#{user_agent_prefix}Shopify API Library v#{VERSION} | Ruby #{RUBY_VERSION}",
           "Accept": "application/json",
         }, T::Hash[T.any(Symbol, String), T.untyped])
+
+        @headers["Host"] = session.shop unless api_host.nil?
 
         unless session.access_token.nil? || T.must(session.access_token).empty?
           @headers["X-Shopify-Access-Token"] = T.cast(session.access_token, String)

--- a/lib/shopify_api/context.rb
+++ b/lib/shopify_api/context.rb
@@ -8,6 +8,7 @@ module ShopifyAPI
     @api_key = T.let("", String)
     @api_secret_key = T.let("", String)
     @api_version = T.let(LATEST_SUPPORTED_ADMIN_VERSION, String)
+    @api_host = T.let(nil, T.nilable(String))
     @scope = T.let(Auth::AuthScopes.new, Auth::AuthScopes)
     @is_private = T.let(false, T::Boolean)
     @private_shop = T.let(nil, T.nilable(String))
@@ -41,6 +42,7 @@ module ShopifyAPI
           private_shop: T.nilable(String),
           user_agent_prefix: T.nilable(String),
           old_api_secret_key: T.nilable(String),
+          api_host: T.nilable(String),
         ).void
       end
       def setup(
@@ -56,7 +58,8 @@ module ShopifyAPI
         host: ENV["HOST"] || "https://#{host_name}",
         private_shop: nil,
         user_agent_prefix: nil,
-        old_api_secret_key: nil
+        old_api_secret_key: nil,
+        api_host: nil
       )
         unless ShopifyAPI::AdminVersions::SUPPORTED_ADMIN_VERSIONS.include?(api_version)
           raise Errors::UnsupportedVersionError,
@@ -66,6 +69,7 @@ module ShopifyAPI
         @api_key = api_key
         @api_secret_key = api_secret_key
         @api_version = api_version
+        @api_host = api_host
         @host = T.let(host, T.nilable(String))
         @is_private = is_private
         @scope = Auth::AuthScopes.new(scope)
@@ -130,7 +134,7 @@ module ShopifyAPI
       end
 
       sig { returns(T.nilable(String)) }
-      attr_reader :private_shop, :user_agent_prefix, :old_api_secret_key, :host
+      attr_reader :private_shop, :user_agent_prefix, :old_api_secret_key, :host, :api_host
 
       sig { returns(T::Boolean) }
       def embedded?

--- a/test/clients/http_client_test.rb
+++ b/test/clients/http_client_test.rb
@@ -54,6 +54,30 @@ module ShopifyAPITest
         simple_http_test(:get)
       end
 
+      def test_request_with_api_host_set
+        @success_body = {}
+
+        ShopifyAPI::Context.setup(
+          api_key: "key",
+          api_secret_key: "secret",
+          api_version: "2023-10",
+          scope: ["scope1", "scope2"],
+          is_private: true,
+          is_embedded: true,
+          api_host: "example.com",
+        )
+        @client = ShopifyAPI::Clients::HttpClient.new(session: @session, base_path: @base_path)
+
+        headers = @expected_headers.dup
+        headers["Host"] = @session.shop
+
+        stub_request(@request.http_method, "https://example.com#{@base_path}/#{@request.path}")
+          .with(body: @request.body.to_json, query: @request.query, headers: headers)
+          .to_return(body: "", headers: @response_headers, status: 204)
+
+        verify_http_request
+      end
+
       def test_request_using_active_session
         ShopifyAPI::Context.activate_session(@session)
         @client = ShopifyAPI::Clients::HttpClient.new(base_path: @base_path)

--- a/test/context_test.rb
+++ b/test/context_test.rb
@@ -21,6 +21,7 @@ module ShopifyAPITest
         private_shop: "privateshop.myshopify.com",
         user_agent_prefix: "user_agent_prefix1",
         old_api_secret_key: "old_secret",
+        api_host: "example.com",
       )
     end
 
@@ -44,6 +45,7 @@ module ShopifyAPITest
       assert_equal("old_secret", ShopifyAPI::Context.old_api_secret_key)
       assert_equal("http", ShopifyAPI::Context.host_scheme)
       assert_equal("localhost", ShopifyAPI::Context.host_name)
+      assert_equal("example.com", ShopifyAPI::Context.api_host)
     end
 
     def test_active_session_is_thread_safe


### PR DESCRIPTION
RE: https://github.com/Shopify/shopify-api-ruby/issues/1235

This PR adds new `api_host` "setting" to `Context`. The `HttpClient` will use `api_host` when set, otherwise default to calling the API as specified by the `session.shop` value.

Whilst this feels a little weird to add this value to `Context`, it seems to be way the `ShopifyAPI` gem is "configurable" by consumers.

## How has this been tested?

Unit tests in this project and using this branch in a service.

## Checklist:

- [x] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the project documentation.
- [x] I have added a changelog line.
