### PR TITLE
Add expired? method to check if session is expired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Note: For changes to the API, see https://shopify.dev/changelog?filter=api
 
 ## Unreleased
 
+- [#1244](https://github.com/Shopify/shopify-api-ruby/pull/1244) Add `expired?` to `ShopifyAPI::Auth::Session` to check if the session is expired (mainly for user sessions)
+
 ## 13.3.0
 
 - [#1241](https://github.com/Shopify/shopify-api-ruby/pull/1241) Add `api_host` to `ShopifyAPI::Context.setup`, allowing the API host to be overridden in `ShopifyAPI::Clients::HttpClient`. This context option is intended for internal Shopify use only.

--- a/lib/shopify_api/auth/session.rb
+++ b/lib/shopify_api/auth/session.rb
@@ -35,6 +35,11 @@ module ShopifyAPI
         @is_online
       end
 
+      sig { returns(T::Boolean) }
+      def expired?
+        @expires ? @expires < Time.now : false
+      end
+
       sig do
         params(
           shop: String,

--- a/test/auth/session_test.rb
+++ b/test/auth/session_test.rb
@@ -34,6 +34,24 @@ module ShopifyAPITest
         assert(session.online?)
       end
 
+      def test_expired_with_no_expiry_date
+        session = ShopifyAPI::Auth::Session.new(shop: "test-shop")
+
+        assert_equal(false, session.expired?)
+      end
+
+      def test_expired_with_future_expiry_date
+        session = ShopifyAPI::Auth::Session.new(shop: "test-shop", expires: Time.now + 1 * 60 * 60)
+
+        assert_equal(false, session.expired?)
+      end
+
+      def test_expired_with_passed_expiry_date
+        session = ShopifyAPI::Auth::Session.new(shop: "test-shop", expires: Time.now - 1)
+
+        assert(session.expired?)
+      end
+
       def test_temp
         session = ShopifyAPI::Auth::Session.new(shop: "test-shop1", access_token: "token1")
 


### PR DESCRIPTION
## Description

### What is the problem it is solving?

There isn't currently a method available to check if an auth session is expired (for online tokens mainly). It's up to each app to implement the method if they want to do such check. This PR adds an `expired?` method to the `Session` that will check the `expires` attribute if it exists.

### What is the context of these changes?

We are planning to add a check on the expiry date in `shopify_app` to trigger an early re-auth, and having that method will make the check cleaner

### What is the impact of this PR?

A new method can be used to check if the session is expired. No impact as long as it's not used

## How has this been tested?

Unit tests provided in the PR

## Checklist:

- [X] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have performed a self-review of my own code.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the project documentation.
- [x] I have added a changelog line.
