### PR TITLE
Add dot notation accessing for graphql responses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -57,6 +57,8 @@ Layout/EmptyLineAfterGuardClause:
   Enabled: true
 Style/GlobalStdStream:
   Enabled: true
+Style/OpenStructUse:
+  Enabled: false
 Layout/LineLength:
   Exclude:
     - "test/clients/*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Note: For changes to the API, see https://shopify.dev/changelog?filter=api
 
 ## Unreleased
+[#1210](https://github.com/Shopify/shopify-api-ruby/pull/1246) Add context option `response_as_struct` to allow GraphQL API responses to be accessed via dot notation.
 
 ## 13.3.0
 

--- a/lib/shopify_api/clients/graphql/client.rb
+++ b/lib/shopify_api/clients/graphql/client.rb
@@ -42,6 +42,7 @@ module ShopifyAPI
               body_type: "application/json",
               tries: tries,
             ),
+            response_as_struct: Context.response_as_struct || false,
           )
         end
       end

--- a/lib/shopify_api/clients/http_client.rb
+++ b/lib/shopify_api/clients/http_client.rb
@@ -32,8 +32,8 @@ module ShopifyAPI
         end
       end
 
-      sig { params(request: HttpRequest).returns(HttpResponse) }
-      def request(request)
+      sig { params(request: HttpRequest, response_as_struct: T::Boolean).returns(HttpResponse) }
+      def request(request, response_as_struct: false)
         request.verify
 
         headers = @headers
@@ -58,6 +58,11 @@ module ShopifyAPI
             raise if res.code.to_i < 500
 
             body = res.body
+          end
+
+          if response_as_struct && body.is_a?(Hash)
+            json_body = body.to_json
+            body = JSON.parse(json_body, object_class: OpenStruct)
           end
 
           response = HttpResponse.new(code: res.code.to_i, headers: res.headers.to_h, body: body)

--- a/lib/shopify_api/clients/http_response.rb
+++ b/lib/shopify_api/clients/http_response.rb
@@ -22,18 +22,13 @@ module ShopifyAPI
         params(
           code: Integer,
           headers: T::Hash[String, T::Array[String]],
-          body: T.any(T::Hash[String, T.untyped], String),
+          body: T.any(T::Hash[String, T.untyped], String, OpenStruct),
         ).void
       end
       def initialize(code:, headers:, body:)
         @code = code
         @headers = headers
-        @body = T.let(body, T.any(OpenStruct, T::Hash[String, T.untyped], String))
-
-        if Context.graphql_response_object && body.is_a?(Hash)
-          json_body = body.to_json
-+         @body = JSON.parse(json_body, object_class: OpenStruct)
-        end
+        @body = body
 
         @prev_page_info = T.let(nil, T.nilable(String))
         @next_page_info = T.let(nil, T.nilable(String))

--- a/lib/shopify_api/clients/http_response.rb
+++ b/lib/shopify_api/clients/http_response.rb
@@ -12,7 +12,7 @@ module ShopifyAPI
       sig { returns(T::Hash[String, T::Array[String]]) }
       attr_reader :headers
 
-      sig { returns(T.any(T::Hash[String, T.untyped], String)) }
+      sig { returns(T.any(T::Hash[String, T.untyped], String, OpenStruct)) }
       attr_reader :body
 
       sig { returns(T.nilable(String)) }
@@ -28,7 +28,12 @@ module ShopifyAPI
       def initialize(code:, headers:, body:)
         @code = code
         @headers = headers
-        @body = body
+        @body = T.let(body, T.any(OpenStruct, T::Hash[String, T.untyped], String))
+
+        if Context.graphql_response_object && body.is_a?(Hash)
+          json_body = body.to_json
++         @body = JSON.parse(json_body, object_class: OpenStruct)
+        end
 
         @prev_page_info = T.let(nil, T.nilable(String))
         @next_page_info = T.let(nil, T.nilable(String))

--- a/lib/shopify_api/context.rb
+++ b/lib/shopify_api/context.rb
@@ -21,6 +21,7 @@ module ShopifyAPI
     @active_session = T.let(Concurrent::ThreadLocalVar.new { nil }, T.nilable(Concurrent::ThreadLocalVar))
     @user_agent_prefix = T.let(nil, T.nilable(String))
     @old_api_secret_key = T.let(nil, T.nilable(String))
+    @graphql_response_object = T.let(false, T.nilable(T::Boolean))
 
     @rest_resource_loader = T.let(nil, T.nilable(Zeitwerk::Loader))
 
@@ -43,6 +44,7 @@ module ShopifyAPI
           user_agent_prefix: T.nilable(String),
           old_api_secret_key: T.nilable(String),
           api_host: T.nilable(String),
+          graphql_response_object: T.nilable(T::Boolean),
         ).void
       end
       def setup(
@@ -59,7 +61,8 @@ module ShopifyAPI
         private_shop: nil,
         user_agent_prefix: nil,
         old_api_secret_key: nil,
-        api_host: nil
+        api_host: nil,
+        graphql_response_object: false
       )
         unless ShopifyAPI::AdminVersions::SUPPORTED_ADMIN_VERSIONS.include?(api_version)
           raise Errors::UnsupportedVersionError,
@@ -78,6 +81,7 @@ module ShopifyAPI
         @private_shop = private_shop
         @user_agent_prefix = user_agent_prefix
         @old_api_secret_key = old_api_secret_key
+        @graphql_response_object = graphql_response_object
         @log_level = if valid_log_level?(log_level)
           log_level.to_sym
         else
@@ -127,6 +131,9 @@ module ShopifyAPI
 
       sig { returns(Symbol) }
       attr_reader :log_level
+
+      sig { returns T.nilable(T::Boolean) }
+      attr_reader :graphql_response_object
 
       sig { returns(T::Boolean) }
       def private?

--- a/lib/shopify_api/context.rb
+++ b/lib/shopify_api/context.rb
@@ -21,7 +21,7 @@ module ShopifyAPI
     @active_session = T.let(Concurrent::ThreadLocalVar.new { nil }, T.nilable(Concurrent::ThreadLocalVar))
     @user_agent_prefix = T.let(nil, T.nilable(String))
     @old_api_secret_key = T.let(nil, T.nilable(String))
-    @graphql_response_object = T.let(false, T.nilable(T::Boolean))
+    @response_as_struct = T.let(false, T.nilable(T::Boolean))
 
     @rest_resource_loader = T.let(nil, T.nilable(Zeitwerk::Loader))
 
@@ -44,7 +44,7 @@ module ShopifyAPI
           user_agent_prefix: T.nilable(String),
           old_api_secret_key: T.nilable(String),
           api_host: T.nilable(String),
-          graphql_response_object: T.nilable(T::Boolean),
+          response_as_struct: T.nilable(T::Boolean),
         ).void
       end
       def setup(
@@ -62,7 +62,7 @@ module ShopifyAPI
         user_agent_prefix: nil,
         old_api_secret_key: nil,
         api_host: nil,
-        graphql_response_object: false
+        response_as_struct: false
       )
         unless ShopifyAPI::AdminVersions::SUPPORTED_ADMIN_VERSIONS.include?(api_version)
           raise Errors::UnsupportedVersionError,
@@ -81,7 +81,7 @@ module ShopifyAPI
         @private_shop = private_shop
         @user_agent_prefix = user_agent_prefix
         @old_api_secret_key = old_api_secret_key
-        @graphql_response_object = graphql_response_object
+        @response_as_struct = response_as_struct
         @log_level = if valid_log_level?(log_level)
           log_level.to_sym
         else
@@ -133,7 +133,7 @@ module ShopifyAPI
       attr_reader :log_level
 
       sig { returns T.nilable(T::Boolean) }
-      attr_reader :graphql_response_object
+      attr_reader :response_as_struct
 
       sig { returns(T::Boolean) }
       def private?

--- a/test/clients/http_client_test.rb
+++ b/test/clients/http_client_test.rb
@@ -270,6 +270,16 @@ module ShopifyAPITest
         assert_equal(502, error.code)
       end
 
+      def test_response_as_struct
+        stub_request(@request.http_method, "https://#{@shop}#{@base_path}/#{@request.path}")
+          .with(body: @request.body.to_json, query: @request.query, headers: @expected_headers)
+          .to_return(body: { "key" => { "nested_key" => "nested_value" } }.to_json, headers: @response_headers)
+
+        response = @client.request(@request, response_as_struct: true)
+        assert_kind_of(OpenStruct, response.body)
+        assert_equal("nested_value", response.body.key.nested_key)
+      end
+
       private
 
       def simple_http_test(http_method)

--- a/test/clients/http_response_test.rb
+++ b/test/clients/http_response_test.rb
@@ -45,6 +45,15 @@ module ShopifyAPITest
         assert_equal("page-info", response.prev_page_info)
         assert_equal("other-page-info", response.next_page_info)
       end
+
+      def test_object_response
+        modify_context(graphql_response_object: true)
+
+        # We need to verify that the response body is an OpenStruct object
+        response = ShopifyAPI::Clients::HttpResponse.new(code: 200, headers: {}, body: { "key" => { "nested_key" => "nested_value" }})
+        assert_kind_of(OpenStruct, response.body)
+        assert_equal("nested_value", response.body.key.nested_key)
+      end
     end
   end
 end

--- a/test/clients/http_response_test.rb
+++ b/test/clients/http_response_test.rb
@@ -45,15 +45,6 @@ module ShopifyAPITest
         assert_equal("page-info", response.prev_page_info)
         assert_equal("other-page-info", response.next_page_info)
       end
-
-      def test_object_response
-        modify_context(graphql_response_object: true)
-
-        # We need to verify that the response body is an OpenStruct object
-        response = ShopifyAPI::Clients::HttpResponse.new(code: 200, headers: {}, body: { "key" => { "nested_key" => "nested_value" }})
-        assert_kind_of(OpenStruct, response.body)
-        assert_equal("nested_value", response.body.key.nested_key)
-      end
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -51,7 +51,7 @@ module Test
           private_shop: T.nilable(String),
           user_agent_prefix: T.nilable(String),
           old_api_secret_key: T.nilable(String),
-          graphql_response_object: T.nilable(T::Boolean),
+          response_as_struct: T.nilable(T::Boolean),
         ).void
       end
       def modify_context(
@@ -66,7 +66,7 @@ module Test
         private_shop: "do-not-set",
         user_agent_prefix: nil,
         old_api_secret_key: nil,
-        graphql_response_object: nil
+        response_as_struct: nil
       )
         ShopifyAPI::Context.setup(
           api_key: api_key ? api_key : ShopifyAPI::Context.api_key,
@@ -81,7 +81,7 @@ module Test
           user_agent_prefix: user_agent_prefix ? user_agent_prefix : ShopifyAPI::Context.user_agent_prefix,
           old_api_secret_key: old_api_secret_key ? old_api_secret_key : ShopifyAPI::Context.old_api_secret_key,
           log_level: :off,
-          graphql_response_object: graphql_response_object || ShopifyAPI::Context.graphql_response_object,
+          response_as_struct: response_as_struct || ShopifyAPI::Context.response_as_struct,
         )
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -51,6 +51,7 @@ module Test
           private_shop: T.nilable(String),
           user_agent_prefix: T.nilable(String),
           old_api_secret_key: T.nilable(String),
+          graphql_response_object: T.nilable(T::Boolean),
         ).void
       end
       def modify_context(
@@ -64,7 +65,8 @@ module Test
         logger: nil,
         private_shop: "do-not-set",
         user_agent_prefix: nil,
-        old_api_secret_key: nil
+        old_api_secret_key: nil,
+        graphql_response_object: nil
       )
         ShopifyAPI::Context.setup(
           api_key: api_key ? api_key : ShopifyAPI::Context.api_key,
@@ -79,6 +81,7 @@ module Test
           user_agent_prefix: user_agent_prefix ? user_agent_prefix : ShopifyAPI::Context.user_agent_prefix,
           old_api_secret_key: old_api_secret_key ? old_api_secret_key : ShopifyAPI::Context.old_api_secret_key,
           log_level: :off,
+          graphql_response_object: graphql_response_object || ShopifyAPI::Context.graphql_response_object,
         )
       end
     end


### PR DESCRIPTION
## Description

https://github.com/Shopify/shopify-api-ruby/assets/23265671/144cffa0-aa34-4a5b-a51a-38c07299b5cd



Fixes #1210

Please, include a summary of what the PR is for:
Starting in the version 10 upgrade graphql response were no longer available to be access with dot notation. 

This PR adds a context option(`response_as_struct`) that will return the  graphql API responses as a struct, so that they will be accessible via either dot or hash notation.

```ruby
 created_product = response.body["data"]["productCreate"]["product"]
 created_product2 = response.body.data.productCreate.product
```

## How has this been tested?

* This gem was used locally to test GraphQL, REST, rest resources and install flow

## Checklist:

- [ ] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [ ] I have performed a self-review of my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the project documentation.
- [ ] I have added a changelog line.
