### PR TITLE
[WIP] REST resource API rate limit information

### DIFF
--- a/lib/shopify_api/rest/base.rb
+++ b/lib/shopify_api/rest/base.rb
@@ -79,6 +79,9 @@ module ShopifyAPI
           instance_variable_get(:"@prev_page_info").value = response.prev_page_info
           instance_variable_get(:"@next_page_info").value = response.next_page_info
 
+          instance_variable_get(:"@retry_request_after").value = response.retry_request_after
+          instance_variable_get(:"@api_call_limit").value = response.api_call_limit
+
           create_instances_from_response(response: response, session: T.must(session))
         end
 
@@ -120,6 +123,16 @@ module ShopifyAPI
         sig { returns(T::Boolean) }
         def next_page?
           !instance_variable_get(:"@next_page_info").value.nil?
+        end
+
+        sig { returns T.nilable(Float) }
+        def retry_request_after
+          instance_variable_get(:"@retry_request_after").value
+        end
+
+        sig { returns T.nilable(T::Hash[String, Integer]) }
+        def api_call_limit
+          instance_variable_get(:"@api_call_limit").value
         end
 
         sig { params(attribute: Symbol).returns(T::Boolean) }

--- a/test/clients/base_rest_resource_test.rb
+++ b/test/clients/base_rest_resource_test.rb
@@ -354,6 +354,21 @@ module ShopifyAPITest
         refute(TestHelpers::FakeResource.next_page?)
       end
 
+      def test_api_limit_headers
+        body = { fake_resources: [] }.to_json
+
+        stub_request(:get, "#{@prefix}/fake_resources.json")
+          .to_return(body: body, headers: {
+            "X-Shopify-Shop-Api-Call-Limit" => "40/40",
+            "Retry-After" => "2.0",
+          })
+
+        TestHelpers::FakeResource.all(session: @session)
+        assert(TestHelpers::FakeResource.retry_request_after, 2.0)
+        assert(TestHelpers::FakeResource.api_call_limit[:request_count], 40)
+        assert(TestHelpers::FakeResource.api_call_limit[:bucket_size], 40)
+      end
+
       def test_pagination_is_thread_safe
         response_body = { fake_resources: [] }.to_json
         request_made = false

--- a/test/clients/http_response_test.rb
+++ b/test/clients/http_response_test.rb
@@ -45,6 +45,17 @@ module ShopifyAPITest
         assert_equal("page-info", response.prev_page_info)
         assert_equal("other-page-info", response.next_page_info)
       end
+
+      def test_retry_request_after
+        response = ShopifyAPI::Clients::HttpResponse.new(code: 200, headers: { "retry-after" => ["2.0"] }, body: "")
+        assert_equal(2.0, response.retry_request_after)
+      end
+
+      def test_api_call_limit
+        response = ShopifyAPI::Clients::HttpResponse.new(code: 200, headers: { "x-shopify-shop-api-call-limit" => ["1/40"] }, body: "")
+        assert_equal(1, response.api_call_limit[:request_count])
+        assert_equal(40, response.api_call_limit[:bucket_size])
+      end
     end
   end
 end

--- a/test/test_helpers/fake_resource.rb
+++ b/test/test_helpers/fake_resource.rb
@@ -15,6 +15,8 @@ module TestHelpers
 
     @prev_page_info = T.let(Concurrent::ThreadLocalVar.new { nil }, Concurrent::ThreadLocalVar)
     @next_page_info = T.let(Concurrent::ThreadLocalVar.new { nil }, Concurrent::ThreadLocalVar)
+    @api_call_limit = T.let(Concurrent::ThreadLocalVar.new { nil }, Concurrent::ThreadLocalVar)
+    @retry_request_after = T.let(Concurrent::ThreadLocalVar.new { nil }, Concurrent::ThreadLocalVar)
 
     @read_only_attributes = T.let([:unsaveable_attribute], T::Array[Symbol])
 

--- a/test/test_helpers/fake_resource_with_custom_prefix.rb
+++ b/test/test_helpers/fake_resource_with_custom_prefix.rb
@@ -7,6 +7,8 @@ module TestHelpers
 
     @prev_page_info = T.let(Concurrent::ThreadLocalVar.new { nil }, Concurrent::ThreadLocalVar)
     @next_page_info = T.let(Concurrent::ThreadLocalVar.new { nil }, Concurrent::ThreadLocalVar)
+    @api_call_limit = T.let(Concurrent::ThreadLocalVar.new { nil }, Concurrent::ThreadLocalVar)
+    @retry_request_after = T.let(Concurrent::ThreadLocalVar.new { nil }, Concurrent::ThreadLocalVar)
 
     @has_one = T.let({}, T::Hash[Symbol, Class])
     @has_many = T.let({}, T::Hash[Symbol, Class])


### PR DESCRIPTION
When using rest resources there was no way to access the rate limit info

This was because we do not allow direct access to the headers

Add relevant rate limit info to rest resource as instance vars

## Description

Fixes #<issue-number>

Please, include a summary of what the PR is for:
- What is the problem it is solving?
- What is the context of these changes?
- What is the impact of this PR?

## How has this been tested?

Please, describe the tests that you ran to verify your changes.

## Checklist:

- [ ] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [ ] I have performed a self-review of my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the project documentation.
- [ ] I have added a changelog line.
