### PR TITLE
Allow adding custom headers in REST Resource HTTP calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Note: For changes to the API, see https://shopify.dev/changelog?filter=api
 - [#1254](https://github.com/Shopify/shopify-api-ruby/pull/1254) Introduce token exchange API for fetching access tokens. This feature is currently unstable and cannot be used yet.
 - [#1268](https://github.com/Shopify/shopify-api-ruby/pull/1268) Add [new webhook handler interface](https://github.com/Shopify/shopify-api-ruby/blob/main/docs/usage/webhooks.md#create-a-webhook-handler) to provide `webhook_id ` and `api_version` information to webhook handlers.
 - [#1274](https://github.com/Shopify/shopify-api-ruby/pull/1274) Update sorbet and rbi dependencies. Remove support for ruby 2.7.
+- [#1275](https://github.com/Shopify/shopify-api-ruby/pull/1275) Allow adding custom headers in REST Resource HTTP calls.
 
 ## 13.4.0
 - [#1210](https://github.com/Shopify/shopify-api-ruby/pull/1246) Add context option `response_as_struct` to allow GraphQL API responses to be accessed via dot notation.

--- a/docs/usage/rest.md
+++ b/docs/usage/rest.md
@@ -127,6 +127,16 @@ draft_order.save!
 
 When updating a resource, only the modified attributes, the resource's primary key, and required parameters are sent to the API. The primary key is usually the `id` attribute of the resource, but it can vary if the `primary_key` method is overwritten in the resource's class. The required parameters are identified using the path parameters of the `PUT` endpoint of the resource.
 
+### Headers
+You can add custom headers to the HTTP calls made by methods like `find`, `delete`, `all`, `count`
+by setting the `headers` attribute on the `ShopifyAPI::Rest::Base` class in an initializer, like so:
+
+```ruby
+ShopifyAPI::Rest::Base.headers = { "X-Custom-Header" => "Custom Value" }
+# `find` will call the API endpoint with the custom header
+ShopifyAPI::Customer.find(id: customer_id)
+```
+
 ### Usage Examples
 ⚠️ The [API reference documentation](https://shopify.dev/docs/api/admin-rest) contains more examples on how to use each REST Resources.
 

--- a/lib/shopify_api/rest/base.rb
+++ b/lib/shopify_api/rest/base.rb
@@ -64,6 +64,15 @@ module ShopifyAPI
         sig { returns(T.nilable(T::Hash[T.any(Symbol, String), String])) }
         attr_accessor :headers
 
+        sig { params(subclass: T::Class[T.anything]).returns(T.untyped) }
+        def inherited(subclass)
+          super
+
+          subclass.define_singleton_method(:headers) do
+            ShopifyAPI::Rest::Base.headers
+          end
+        end
+
         sig do
           params(
             session: T.nilable(Auth::Session),

--- a/lib/shopify_api/rest/base.rb
+++ b/lib/shopify_api/rest/base.rb
@@ -10,6 +10,7 @@ module ShopifyAPI
       extend T::Helpers
       abstract!
 
+      @headers = T.let(nil, T.nilable(T::Hash[T.any(Symbol, String), String]))
       @has_one = T.let({}, T::Hash[Symbol, T::Class[T.anything]])
       @has_many = T.let({}, T::Hash[Symbol, T::Class[T.anything]])
       @paths = T.let([], T::Array[T::Hash[Symbol, T.any(T::Array[Symbol], String, Symbol)]])
@@ -60,6 +61,9 @@ module ShopifyAPI
         sig { returns(T::Hash[Symbol, T::Class[T.anything]]) }
         attr_reader :has_one
 
+        sig { returns(T.nilable(T::Hash[T.any(Symbol, String), String])) }
+        attr_accessor :headers
+
         sig do
           params(
             session: T.nilable(Auth::Session),
@@ -73,7 +77,7 @@ module ShopifyAPI
           client = ShopifyAPI::Clients::Rest::Admin.new(session: session)
 
           path = T.must(get_path(http_method: :get, operation: :get, ids: ids))
-          response = client.get(path: path, query: params.compact)
+          response = client.get(path: path, query: params.compact, headers: headers)
 
           instance_variable_get(:"@prev_page_info").value = response.prev_page_info
           instance_variable_get(:"@next_page_info").value = response.next_page_info
@@ -219,13 +223,13 @@ module ShopifyAPI
 
           case http_method
           when :get
-            client.get(path: T.must(path), query: params.compact)
+            client.get(path: T.must(path), query: params.compact, headers: headers)
           when :post
-            client.post(path: T.must(path), query: params.compact, body: body || {})
+            client.post(path: T.must(path), query: params.compact, body: body || {}, headers: headers)
           when :put
-            client.put(path: T.must(path), query: params.compact, body: body || {})
+            client.put(path: T.must(path), query: params.compact, body: body || {}, headers: headers)
           when :delete
-            client.delete(path: T.must(path), query: params.compact)
+            client.delete(path: T.must(path), query: params.compact, headers: headers)
           else
             raise Errors::InvalidHttpRequestError, "Invalid HTTP method: #{http_method}"
           end
@@ -355,6 +359,7 @@ module ShopifyAPI
         @client.delete(
           path: T.must(self.class.get_path(http_method: :delete, operation: :delete, entity: self)),
           query: params.compact,
+          headers: self.class.headers,
         )
       rescue ShopifyAPI::Errors::HttpResponseError => e
         @errors.errors << e
@@ -378,6 +383,7 @@ module ShopifyAPI
           method,
           body: body,
           path: deduce_write_path(method),
+          headers: self.class.headers,
         )
 
         if update_object

--- a/test/clients/base_rest_resource_test.rb
+++ b/test/clients/base_rest_resource_test.rb
@@ -77,14 +77,12 @@ module ShopifyAPITest
       end
 
       def test_finds_all_resources_with_headers
-        ShopifyAPI::Rest::Base.headers = { "X-Shopify-Test" => "test" }
+        ShopifyAPI::Rest::Base.stubs(:headers).returns({ "X-Shopify-Test" => "test" })
 
         stub_request(:get, "#{@prefix}/fake_resources.json")
           .with(headers: { "X-Shopify-Test" => "test" })
 
         TestHelpers::FakeResource.all(session: @session)
-
-        ShopifyAPI::Rest::Base.headers = {}
       end
 
       def test_saves

--- a/test/clients/base_rest_resource_test.rb
+++ b/test/clients/base_rest_resource_test.rb
@@ -85,6 +85,42 @@ module ShopifyAPITest
         TestHelpers::FakeResource.all(session: @session)
       end
 
+      def test_update_resource_with_headers
+        ShopifyAPI::Rest::Base.stubs(:headers).returns({ "X-Shopify-Test" => "test" })
+
+        stub_request(:put, "#{@prefix}/fake_resources/1.json")
+          .with(headers: { "X-Shopify-Test" => "test" })
+
+        fake_resource = TestHelpers::FakeResource.new(session: @session)
+        fake_resource.id = 1
+        fake_resource.attribute = "updated"
+
+        assert fake_resource.save
+      end
+
+      def test_create_resource_with_headers
+        ShopifyAPI::Rest::Base.stubs(:headers).returns({ "X-Shopify-Test" => "test" })
+
+        stub_request(:post, "#{@prefix}/fake_resources.json")
+          .with(headers: { "X-Shopify-Test" => "test" })
+
+        fake_resource = TestHelpers::FakeResource.new(session: @session)
+        fake_resource.attribute = "create"
+
+        assert fake_resource.save
+      end
+
+      def test_delete_resource_with_headers
+        ShopifyAPI::Rest::Base.stubs(:headers).returns({ "X-Shopify-Test" => "test" })
+
+        stub_request(:delete, "#{@prefix}/fake_resources/1.json")
+          .with(headers: { "X-Shopify-Test" => "test" })
+
+        fake_resource = TestHelpers::FakeResource.new(session: @session)
+        fake_resource.id = 1
+        assert fake_resource.delete
+      end
+
       def test_saves
         request_body = { fake_resource: { attribute: "attribute" } }.to_json
         response_body = { fake_resource: { id: 1, attribute: "attribute" } }.to_json

--- a/test/clients/base_rest_resource_test.rb
+++ b/test/clients/base_rest_resource_test.rb
@@ -76,6 +76,17 @@ module ShopifyAPITest
         assert_equal([2, "attribute2"], [got[1].id, got[1].attribute])
       end
 
+      def test_finds_all_resources_with_headers
+        ShopifyAPI::Rest::Base.headers = { "X-Shopify-Test" => "test" }
+
+        stub_request(:get, "#{@prefix}/fake_resources.json")
+          .with(headers: { "X-Shopify-Test" => "test" })
+
+        TestHelpers::FakeResource.all(session: @session)
+
+        ShopifyAPI::Rest::Base.headers = {}
+      end
+
       def test_saves
         request_body = { fake_resource: { attribute: "attribute" } }.to_json
         response_body = { fake_resource: { id: 1, attribute: "attribute" } }.to_json
@@ -428,6 +439,7 @@ module ShopifyAPITest
           body: { "product" => { "metafields" => [{ "key" => "new", "value" => "newvalue", "type" => "single_line_text_field",
                                                     "namespace" => "global", }], "id" => 632910392, } },
           path: "products/632910392.json",
+          headers: nil,
         )
         product.metafields = [
           {
@@ -452,6 +464,7 @@ module ShopifyAPITest
         customer.client.expects(:put).with(
           body: { "customer" => { "tags" => "New Customer, Repeat Customer", "id" => 207119551 } },
           path: "customers/207119551.json",
+          headers: nil,
         )
         customer.tags = "New Customer, Repeat Customer"
 
@@ -500,6 +513,7 @@ module ShopifyAPITest
         variant.client.expects(:put).with(
           body: { "variant" => { "barcode" => "1234", "id" => 169 } },
           path: "variants/169.json",
+          headers: nil,
         )
         variant.barcode = "1234"
         variant.save

--- a/test/clients/base_rest_resource_test.rb
+++ b/test/clients/base_rest_resource_test.rb
@@ -95,7 +95,7 @@ module ShopifyAPITest
         fake_resource.id = 1
         fake_resource.attribute = "updated"
 
-        assert fake_resource.save
+        assert(fake_resource.save)
       end
 
       def test_create_resource_with_headers
@@ -107,7 +107,7 @@ module ShopifyAPITest
         fake_resource = TestHelpers::FakeResource.new(session: @session)
         fake_resource.attribute = "create"
 
-        assert fake_resource.save
+        assert(fake_resource.save)
       end
 
       def test_delete_resource_with_headers
@@ -118,7 +118,7 @@ module ShopifyAPITest
 
         fake_resource = TestHelpers::FakeResource.new(session: @session)
         fake_resource.id = 1
-        assert fake_resource.delete
+        assert(fake_resource.delete)
       end
 
       def test_saves


### PR DESCRIPTION
I've added a new attribute, `ShopifyAPI::Rest::Base.headers`, that can be used to set headers that will be sent with every request made by the resource through methods like `all`, `delete`, etc...

## Description

Fixes https://github.com/Shopify/shopify-api-ruby/issues/1211

## How has this been tested?

I've added an automated test for `all`.

## Checklist:

- [x] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the project documentation.
- [x] I have added a changelog line.
