### PR TITLE
Update webhooks documentation

### DIFF
--- a/docs/usage/webhooks.md
+++ b/docs/usage/webhooks.md
@@ -18,10 +18,10 @@ If you want to register for an http webhook you need to implement a webhook hand
 
 ```ruby
 module WebhookHandler
-  extend ShopifyAPI::Webhooks::Handler
+  extend ShopifyAPI::Webhooks::WebhookHandler
 
   class << self
-    def handle_webhook(data)
+    def handle_webhook(data:)
       puts "Received webhook! topic: #{data.topic} shop: #{data.shop} body: #{data.body} webhook_id: #{data.webhook_id} api_version: #{data.api_version"
     end
   end


### PR DESCRIPTION
## Description

I updated my repositories to use the new webhook handler, but the documentation was slightly wrong.

- The `data` param is passed by name not position ([source](https://github.com/Shopify/shopify-api-ruby/blob/main/lib/shopify_api/webhooks/handler.rb#L35)).
- Use the new module rather than the old one ([deprecation](https://github.com/Shopify/shopify-api-ruby/blob/main/lib/shopify_api/webhooks/registry.rb#L202-L203)).


## Checklist:

- [ ] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have performed a self-review of my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the project documentation.
- [ ] I have added a changelog line.
