### PR TITLE
Adding indifferent access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Note: For changes to the API, see https://shopify.dev/changelog?filter=api
 ## Unreleased
 
 - [#1327](https://github.com/Shopify/shopify-api-ruby/pull/1327) Support `?debug=true` parameter in GraphQL client requests
+- [#1308](https://github.com/Shopify/shopify-api-ruby/pull/1308) Support hash_with_indifferent_access when creating REST objects from Shopify responses. Closes #1296
 
 ## 14.4.0
 

--- a/lib/shopify_api/rest/base.rb
+++ b/lib/shopify_api/rest/base.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "active_support/inflector"
-require 'active_support/all'
+require "active_support/core_ext/hash/indifferent_access"
 
 module ShopifyAPI
   module Rest

--- a/lib/shopify_api/rest/base.rb
+++ b/lib/shopify_api/rest/base.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "active_support/inflector"
+require 'active_support/all'
 
 module ShopifyAPI
   module Rest
@@ -248,7 +249,7 @@ module ShopifyAPI
         def create_instances_from_response(response:, session:)
           objects = []
 
-          body = T.cast(response.body, T::Hash[String, T.untyped])
+          body = T.cast(response.body, T::Hash[String, T.untyped]).with_indifferent_access
 
           response_names = json_response_body_names
 

--- a/sorbet/rbi/shims/hash.rb
+++ b/sorbet/rbi/shims/hash.rb
@@ -1,0 +1,3 @@
+class Hash
+  def with_indifferent_access; end
+end


### PR DESCRIPTION
Tackling issue #1296 Added indifferent access to create_instances_from_response in the ShopifyAPI::Rest::Base class.

## Description

Fixes #<issue-number>

Please, include a summary of what the PR is for:
- What is the problem it is solving?
- What is the context of these changes?
- What is the impact of this PR?

## How has this been tested?

Please, describe the tests that you ran to verify your changes.

## Checklist:

- [ ] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have performed a self-review of my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the project documentation.
- [ ] I have added a changelog line.
