### PR TITLE
Use same leeway for `exp` and `nbf` when parsing JWT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Note: For changes to the API, see https://shopify.dev/changelog?filter=api
 
 ## Unreleased
+- [#1312](https://github.com/Shopify/shopify-api-ruby/pull/1312) Use same leeway for `exp` and `nbf` when parsing JWT
 
 ## 14.2.0
 - [#1309](https://github.com/Shopify/shopify-api-ruby/pull/1309) Add `Session#copy_attributes_from` method

--- a/lib/shopify_api/auth/jwt_payload.rb
+++ b/lib/shopify_api/auth/jwt_payload.rb
@@ -73,8 +73,7 @@ module ShopifyAPI
 
       sig { params(token: String, api_secret_key: String).returns(T::Hash[String, T.untyped]) }
       def decode_token(token, api_secret_key)
-        JWT.decode(token, api_secret_key, true,
-          { exp_leeway: JWT_EXPIRATION_LEEWAY, algorithm: "HS256" })[0]
+        JWT.decode(token, api_secret_key, true, leeway: JWT_EXPIRATION_LEEWAY, algorithm: "HS256")[0]
       rescue JWT::DecodeError => err
         raise ShopifyAPI::Errors::InvalidJwtTokenError, "Error decoding session token: #{err.message}"
       end

--- a/lib/shopify_api/auth/jwt_payload.rb
+++ b/lib/shopify_api/auth/jwt_payload.rb
@@ -6,7 +6,8 @@ module ShopifyAPI
     class JwtPayload
       extend T::Sig
 
-      JWT_EXPIRATION_LEEWAY = 10
+      JWT_LEEWAY = 10
+      JWT_EXPIRATION_LEEWAY = JWT_LEEWAY
 
       sig { returns(String) }
       attr_reader :iss, :dest, :aud, :sub, :jti, :sid
@@ -73,7 +74,7 @@ module ShopifyAPI
 
       sig { params(token: String, api_secret_key: String).returns(T::Hash[String, T.untyped]) }
       def decode_token(token, api_secret_key)
-        JWT.decode(token, api_secret_key, true, leeway: JWT_EXPIRATION_LEEWAY, algorithm: "HS256")[0]
+        JWT.decode(token, api_secret_key, true, leeway: JWT_LEEWAY, algorithm: "HS256")[0]
       rescue JWT::DecodeError => err
         raise ShopifyAPI::Errors::InvalidJwtTokenError, "Error decoding session token: #{err.message}"
       end


### PR DESCRIPTION
## Description

Right now we specify a leeway of 10 seconds when validating JWT payload expiration, but no leeway for `nbf` (not valid before). The `shopify-api` JS [library](https://github.com/Shopify/shopify-app-js/blob/0fd6a80c0af45138240b6b508210d3ef6b9292ee/packages/apps/shopify-api/lib/session/decode-session-token.ts#L25C11-L25C25) does allow for `clockTolerance` in both fields, and I think it makes sense for the Ruby gem to do the same.

## How has this been tested?

I added unit tests.

## Checklist:

- [x] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the project documentation.
- [x] I have added a changelog line.
