### PR TITLE
Update the shop.tax_shipping type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Note: For changes to the API, see https://shopify.dev/changelog?filter=api
 
 ## Unreleased
+- [#1320](https://github.com/Shopify/shopify-api-ruby/pull/1320) Fix sorbet type on Shop.tax_shipping field
 
 ## 14.3.0
 - [#1312](https://github.com/Shopify/shopify-api-ruby/pull/1312) Use same leeway for `exp` and `nbf` when parsing JWT

--- a/lib/shopify_api/rest/resources/2022_04/shop.rb
+++ b/lib/shopify_api/rest/resources/2022_04/shop.rb
@@ -66,7 +66,7 @@ module ShopifyAPI
       @setup_required = T.let(nil, T.nilable(T::Boolean))
       @shop_owner = T.let(nil, T.nilable(String))
       @source = T.let(nil, T.nilable(String))
-      @tax_shipping = T.let(nil, T.nilable(String))
+      @tax_shipping = T.let(nil, T.nilable(T::Boolean))
       @taxes_included = T.let(nil, T.nilable(T::Boolean))
       @timezone = T.let(nil, T.nilable(String))
       @transactional_sms_disabled = T.let(nil, T.nilable(T::Boolean))
@@ -179,7 +179,7 @@ module ShopifyAPI
     attr_reader :shop_owner
     sig { returns(T.nilable(String)) }
     attr_reader :source
-    sig { returns(T.nilable(String)) }
+    sig { returns(T.nilable(T::Boolean)) }
     attr_reader :tax_shipping
     sig { returns(T.nilable(T::Boolean)) }
     attr_reader :taxes_included

--- a/lib/shopify_api/rest/resources/2022_07/shop.rb
+++ b/lib/shopify_api/rest/resources/2022_07/shop.rb
@@ -66,7 +66,7 @@ module ShopifyAPI
       @setup_required = T.let(nil, T.nilable(T::Boolean))
       @shop_owner = T.let(nil, T.nilable(String))
       @source = T.let(nil, T.nilable(String))
-      @tax_shipping = T.let(nil, T.nilable(String))
+      @tax_shipping = T.let(nil, T.nilable(T::Boolean))
       @taxes_included = T.let(nil, T.nilable(T::Boolean))
       @timezone = T.let(nil, T.nilable(String))
       @transactional_sms_disabled = T.let(nil, T.nilable(T::Boolean))
@@ -179,7 +179,7 @@ module ShopifyAPI
     attr_reader :shop_owner
     sig { returns(T.nilable(String)) }
     attr_reader :source
-    sig { returns(T.nilable(String)) }
+    sig { returns(T.nilable(T::Boolean)) }
     attr_reader :tax_shipping
     sig { returns(T.nilable(T::Boolean)) }
     attr_reader :taxes_included

--- a/lib/shopify_api/rest/resources/2022_10/shop.rb
+++ b/lib/shopify_api/rest/resources/2022_10/shop.rb
@@ -66,7 +66,7 @@ module ShopifyAPI
       @setup_required = T.let(nil, T.nilable(T::Boolean))
       @shop_owner = T.let(nil, T.nilable(String))
       @source = T.let(nil, T.nilable(String))
-      @tax_shipping = T.let(nil, T.nilable(String))
+      @tax_shipping = T.let(nil, T.nilable(T::Boolean))
       @taxes_included = T.let(nil, T.nilable(T::Boolean))
       @timezone = T.let(nil, T.nilable(String))
       @transactional_sms_disabled = T.let(nil, T.nilable(T::Boolean))
@@ -179,7 +179,7 @@ module ShopifyAPI
     attr_reader :shop_owner
     sig { returns(T.nilable(String)) }
     attr_reader :source
-    sig { returns(T.nilable(String)) }
+    sig { returns(T.nilable(T::Boolean)) }
     attr_reader :tax_shipping
     sig { returns(T.nilable(T::Boolean)) }
     attr_reader :taxes_included

--- a/lib/shopify_api/rest/resources/2023_01/shop.rb
+++ b/lib/shopify_api/rest/resources/2023_01/shop.rb
@@ -66,7 +66,7 @@ module ShopifyAPI
       @setup_required = T.let(nil, T.nilable(T::Boolean))
       @shop_owner = T.let(nil, T.nilable(String))
       @source = T.let(nil, T.nilable(String))
-      @tax_shipping = T.let(nil, T.nilable(String))
+      @tax_shipping = T.let(nil, T.nilable(T::Boolean))
       @taxes_included = T.let(nil, T.nilable(T::Boolean))
       @timezone = T.let(nil, T.nilable(String))
       @transactional_sms_disabled = T.let(nil, T.nilable(T::Boolean))
@@ -179,7 +179,7 @@ module ShopifyAPI
     attr_reader :shop_owner
     sig { returns(T.nilable(String)) }
     attr_reader :source
-    sig { returns(T.nilable(String)) }
+    sig { returns(T.nilable(T::Boolean)) }
     attr_reader :tax_shipping
     sig { returns(T.nilable(T::Boolean)) }
     attr_reader :taxes_included

--- a/lib/shopify_api/rest/resources/2023_04/shop.rb
+++ b/lib/shopify_api/rest/resources/2023_04/shop.rb
@@ -66,7 +66,7 @@ module ShopifyAPI
       @setup_required = T.let(nil, T.nilable(T::Boolean))
       @shop_owner = T.let(nil, T.nilable(String))
       @source = T.let(nil, T.nilable(String))
-      @tax_shipping = T.let(nil, T.nilable(String))
+      @tax_shipping = T.let(nil, T.nilable(T::Boolean))
       @taxes_included = T.let(nil, T.nilable(T::Boolean))
       @timezone = T.let(nil, T.nilable(String))
       @transactional_sms_disabled = T.let(nil, T.nilable(T::Boolean))
@@ -179,7 +179,7 @@ module ShopifyAPI
     attr_reader :shop_owner
     sig { returns(T.nilable(String)) }
     attr_reader :source
-    sig { returns(T.nilable(String)) }
+    sig { returns(T.nilable(T::Boolean)) }
     attr_reader :tax_shipping
     sig { returns(T.nilable(T::Boolean)) }
     attr_reader :taxes_included

--- a/lib/shopify_api/rest/resources/2023_07/shop.rb
+++ b/lib/shopify_api/rest/resources/2023_07/shop.rb
@@ -66,7 +66,7 @@ module ShopifyAPI
       @setup_required = T.let(nil, T.nilable(T::Boolean))
       @shop_owner = T.let(nil, T.nilable(String))
       @source = T.let(nil, T.nilable(String))
-      @tax_shipping = T.let(nil, T.nilable(String))
+      @tax_shipping = T.let(nil, T.nilable(T::Boolean))
       @taxes_included = T.let(nil, T.nilable(T::Boolean))
       @timezone = T.let(nil, T.nilable(String))
       @transactional_sms_disabled = T.let(nil, T.nilable(T::Boolean))
@@ -179,7 +179,7 @@ module ShopifyAPI
     attr_reader :shop_owner
     sig { returns(T.nilable(String)) }
     attr_reader :source
-    sig { returns(T.nilable(String)) }
+    sig { returns(T.nilable(T::Boolean)) }
     attr_reader :tax_shipping
     sig { returns(T.nilable(T::Boolean)) }
     attr_reader :taxes_included

--- a/lib/shopify_api/rest/resources/2023_10/shop.rb
+++ b/lib/shopify_api/rest/resources/2023_10/shop.rb
@@ -66,7 +66,7 @@ module ShopifyAPI
       @setup_required = T.let(nil, T.nilable(T::Boolean))
       @shop_owner = T.let(nil, T.nilable(String))
       @source = T.let(nil, T.nilable(String))
-      @tax_shipping = T.let(nil, T.nilable(String))
+      @tax_shipping = T.let(nil, T.nilable(T::Boolean))
       @taxes_included = T.let(nil, T.nilable(T::Boolean))
       @timezone = T.let(nil, T.nilable(String))
       @transactional_sms_disabled = T.let(nil, T.nilable(T::Boolean))
@@ -179,7 +179,7 @@ module ShopifyAPI
     attr_reader :shop_owner
     sig { returns(T.nilable(String)) }
     attr_reader :source
-    sig { returns(T.nilable(String)) }
+    sig { returns(T.nilable(T::Boolean)) }
     attr_reader :tax_shipping
     sig { returns(T.nilable(T::Boolean)) }
     attr_reader :taxes_included

--- a/lib/shopify_api/rest/resources/2024_01/shop.rb
+++ b/lib/shopify_api/rest/resources/2024_01/shop.rb
@@ -66,7 +66,7 @@ module ShopifyAPI
       @setup_required = T.let(nil, T.nilable(T::Boolean))
       @shop_owner = T.let(nil, T.nilable(String))
       @source = T.let(nil, T.nilable(String))
-      @tax_shipping = T.let(nil, T.nilable(String))
+      @tax_shipping = T.let(nil, T.nilable(T::Boolean))
       @taxes_included = T.let(nil, T.nilable(T::Boolean))
       @timezone = T.let(nil, T.nilable(String))
       @transactional_sms_disabled = T.let(nil, T.nilable(T::Boolean))
@@ -179,7 +179,7 @@ module ShopifyAPI
     attr_reader :shop_owner
     sig { returns(T.nilable(String)) }
     attr_reader :source
-    sig { returns(T.nilable(String)) }
+    sig { returns(T.nilable(T::Boolean)) }
     attr_reader :tax_shipping
     sig { returns(T.nilable(T::Boolean)) }
     attr_reader :taxes_included

--- a/lib/shopify_api/rest/resources/2024_04/shop.rb
+++ b/lib/shopify_api/rest/resources/2024_04/shop.rb
@@ -66,7 +66,7 @@ module ShopifyAPI
       @setup_required = T.let(nil, T.nilable(T::Boolean))
       @shop_owner = T.let(nil, T.nilable(String))
       @source = T.let(nil, T.nilable(String))
-      @tax_shipping = T.let(nil, T.nilable(String))
+      @tax_shipping = T.let(nil, T.nilable(T::Boolean))
       @taxes_included = T.let(nil, T.nilable(T::Boolean))
       @timezone = T.let(nil, T.nilable(String))
       @transactional_sms_disabled = T.let(nil, T.nilable(T::Boolean))
@@ -179,7 +179,7 @@ module ShopifyAPI
     attr_reader :shop_owner
     sig { returns(T.nilable(String)) }
     attr_reader :source
-    sig { returns(T.nilable(String)) }
+    sig { returns(T.nilable(T::Boolean)) }
     attr_reader :tax_shipping
     sig { returns(T.nilable(T::Boolean)) }
     attr_reader :taxes_included


### PR DESCRIPTION
## Description

Fixes #1271 

The `tax_shipping` field will be `null` on newly created stores. `true` when enabled and `false` when subsequently disabled.

## How has this been tested?

* Tested in a development app

## Checklist:

- [x] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have performed a self-review of my own code.
- [x] I have added a changelog line.
