### PR TITLE
Patch JwtPayload in order to correctly parse Checkout UI extensions session tokens

### DIFF
--- a/lib/shopify_api/auth/jwt_payload.rb
+++ b/lib/shopify_api/auth/jwt_payload.rb
@@ -27,7 +27,7 @@ module ShopifyAPI
           decode_token(token, T.must(Context.old_api_secret_key))
         end
 
-        @iss = T.let(payload_hash["iss"], String)
+        @iss = T.let(payload_hash["iss"], T.nilable(String))
         @dest = T.let(payload_hash["dest"], String)
         @aud = T.let(payload_hash["aud"], String)
         @sub = T.let(payload_hash["sub"], String)
@@ -35,7 +35,7 @@ module ShopifyAPI
         @nbf = T.let(payload_hash["nbf"], Integer)
         @iat = T.let(payload_hash["iat"], Integer)
         @jti = T.let(payload_hash["jti"], String)
-        @sid = T.let(payload_hash["sid"], String)
+        @sid = T.let(payload_hash["sid"], T.nilable(String))
 
         raise ShopifyAPI::Errors::InvalidJwtTokenError,
           "Session token had invalid API key" unless @aud == Context.api_key
@@ -49,7 +49,7 @@ module ShopifyAPI
 
       sig { returns(Integer) }
       def shopify_user_id
-        @sub.to_i
+        @sub.tr("^0-9", "").to_i
       end
 
       # TODO: Remove before releasing v11


### PR DESCRIPTION
Checkout UI session tokens are actually missing "iss" and "sid" keys (see: https://shopify.dev/docs/api/checkout-ui-extensions/2024-10/apis/session-token). The current implementation makes them mandatory, generating exceptions while verifying JWT tokens (see the new `ShopifyApp::WithShopifyIdToken` concern, and the legacy `ShopifyApp::JWTMiddleware` middleware).

## Description

The PR is for:
- Solving exceptions raised in the `ShopifyAPI::Auth::JwtPayload` constructor (line 30) when the JWT Token is missing the "iss" and "sid" keys (both optional in Checkout UI session tokens)
- Any Checkout UI extension making authenticated API calls to an endpoint developed using the `ShopifyApp` engine fails, raising an obscure exception
- PR impact: make "iss" and "sid" keys optional, and extract the correct `shopify_user_id` from the "sid" key, even when it's formatted as `gid://shopify/Customer/<customerId>`

## How has this been tested?

Develop a basic frontend Checkout UI extension and make cors authenticated calls to a Rails backend developed using `shopify_app` gem (v22.4). Any request fails without reaching the corresponding controller, since an exception is raised in the `ShopifyApp::JWTMiddleware` middleware injected by the `ShopifyApp` engine (see `engine.rb`, row 20).
After applying the patch, requests are nomally executed without raising any exception.

## Checklist:

- [ ] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [X] I have performed a self-review of my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the project documentation.
- [ ] I have added a changelog line.
