### PR TITLE
Support internal Shopify hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Note: For changes to the API, see https://shopify.dev/changelog?filter=api
 
 - [#1362](https://github.com/Shopify/shopify-api-ruby/pull/1362) Add support for client credentials grant
 - [#1369](https://github.com/Shopify/shopify-api-ruby/pull/1369) Make `sub` and `sid` jwt claims optional (Checkout ui extension support)
+- [#1370](https://github.com/Shopify/shopify-api-ruby/pull/1370) Add support for Shopify internal hosts
 
 ## 14.8.0
 

--- a/lib/shopify_api/auth/oauth.rb
+++ b/lib/shopify_api/auth/oauth.rb
@@ -46,8 +46,8 @@ module ShopifyAPI
           }
 
           query_string = URI.encode_www_form(query)
+          auth_route = auth_base_uri(shop) + "/oauth/authorize?#{query_string}"
 
-          auth_route = "https://#{shop}/admin/oauth/authorize?#{query_string}"
           { auth_route: auth_route, cookie: cookie }
         end
 
@@ -105,6 +105,20 @@ module ShopifyAPI
           end
 
           { session: session, cookie: cookie }
+        end
+
+        private
+
+        sig { params(shop: String).returns(String) }
+        def auth_base_uri(shop)
+          return "https://#{shop}/admin" unless defined?(DevServer)
+
+          # For first-party apps in development only, we leverage DevServer to build the admin base URI
+          admin_web = T.unsafe(Object.const_get("DevServer")).new("web") # rubocop:disable Sorbet/ConstantsFromStrings
+          admin_host = admin_web.host!(nonstandard_host_prefix: "admin")
+          shop_name = shop.split(".").first
+
+          "https://#{admin_host}/store/#{shop_name}"
         end
       end
     end

--- a/lib/shopify_api/clients/http_client.rb
+++ b/lib/shopify_api/clients/http_client.rb
@@ -39,6 +39,10 @@ module ShopifyAPI
         headers = @headers
         headers["Content-Type"] = T.must(request.body_type) if request.body_type
         headers = headers.merge(T.must(request.extra_headers)) if request.extra_headers
+        if headers["Host"].include?(".my.shop.dev")
+          headers["x-forwarded-host"] = headers["Host"]
+          headers["Host"] = "app.shop.dev"
+        end
 
         tries = 0
         response = HttpResponse.new(code: 0, headers: {}, body: "")


### PR DESCRIPTION
## Description
Fixes https://github.com/Shopify/shop-server/issues/101259

In this PR, we add support for new Shopify internal hosts by rewriting the host to a generic one and passing the storefront domain as a `X-Forwarded-Host`. This change enables the installation of Shopify Apps, internally, in development.

We only filter on Shopify internal local development hosts so impact should be null in any other situation.

## How has this been tested?
This was successfully tested. Please check the testing instructions in the linked issue.

## Checklist:

- [x] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the project documentation.
- [ ] I have added a changelog line.
