### PR TITLE
add optional ShopifyAPI::Context::httparty_params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Note: For changes to the API, see https://shopify.dev/changelog?filter=api
 ## Unreleased
+- [#1375](https://github.com/Shopify/shopify-api-ruby/pull/1375) add optional `ShopifyAPI::Context::httparty_params` to configure HTTP request params such as timeout, debug_output, or proxy settings.
 - [#1443](https://github.com/Shopify/shopify-api-ruby/pull/1443) Add `ShopifyAPI::Utils::ShopValidator` (module) with `sanitize_shop_domain` and `sanitize!`.
 - [#1443](https://github.com/Shopify/shopify-api-ruby/pull/1443) `ShopifyAPI::Auth::TokenExchange.exchange_token` always uses the session token's `dest` claim, instead of the `shop` parameter, that is now deprecated. It will show a deprecation warning and the argument will be removed in the next major version.
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,24 @@ ShopifyAPI::Context.setup(
 )
 ```
 
+Optionally, you can override HTTP request params such as timeout, debug_output, or proxy settings.  
+```ruby
+ShopifyAPI::Context.setup(
+  # other params...
+  httparty_params: {
+    timeout: 60, # Set the open/read/write timeout for HTTP requests
+    open_timeout: 60, # Set the open timeout for HTTP requests
+    read_timeout: 60, # Set the read timeout for HTTP requests
+    write_timeout: 60, # Set the write timeout for HTTP requests
+    debug_output: false, # Set to true to enable debug output for HTTP requests
+    http_proxyaddr: "http://proxy.example.com:8080", # Set the HTTP proxy address
+    http_proxyport: 8080, # Set the HTTP proxy port
+    http_proxyuser: "username", # Set the HTTP proxy username
+    http_proxypass: "password", # Set the HTTP proxy password
+  }
+)
+```
+
 ### Performing OAuth
 
 You need to go through OAuth as described [here](https://shopify.dev/docs/apps/auth/oauth) to create sessions for shops using your app.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ ShopifyAPI::Context.setup(
     read_timeout: 60, # Set the read timeout for HTTP requests
     write_timeout: 60, # Set the write timeout for HTTP requests
     debug_output: false, # Set to true to enable debug output for HTTP requests
-    http_proxyaddr: "http://proxy.example.com:8080", # Set the HTTP proxy address
+    http_proxyaddr: "proxy.example.com", # Set the HTTP proxy address (hostname only, no scheme or port)
     http_proxyport: 8080, # Set the HTTP proxy port
     http_proxyuser: "username", # Set the HTTP proxy username
     http_proxypass: "password", # Set the HTTP proxy password

--- a/lib/shopify_api/clients/http_client.rb
+++ b/lib/shopify_api/clients/http_client.rb
@@ -51,6 +51,7 @@ module ShopifyAPI
           res = T.cast(HTTParty.send(
             request.http_method,
             parsed_uri.to_s,
+            **Context.httparty_params,
             headers: headers,
             query: request.query,
             body: request.body.class == Hash ? T.unsafe(request.body).to_json : request.body,

--- a/lib/shopify_api/clients/http_client.rb
+++ b/lib/shopify_api/clients/http_client.rb
@@ -51,7 +51,7 @@ module ShopifyAPI
           res = T.cast(HTTParty.send(
             request.http_method,
             parsed_uri.to_s,
-            **Context.httparty_params,
+            **(Context.httparty_params || {}),
             headers: headers,
             query: request.query,
             body: request.body.class == Hash ? T.unsafe(request.body).to_json : request.body,

--- a/lib/shopify_api/context.rb
+++ b/lib/shopify_api/context.rb
@@ -27,6 +27,8 @@ module ShopifyAPI
     @rest_resource_loader = T.let(nil, T.nilable(Zeitwerk::Loader))
     @expiring_offline_access_tokens = T.let(false, T::Boolean)
 
+    @httparty_params = T.let({}, T::Hash[Symbol, T.untyped])
+
     class << self
       extend T::Sig
 
@@ -49,6 +51,7 @@ module ShopifyAPI
           response_as_struct: T.nilable(T::Boolean),
           rest_disabled: T.nilable(T::Boolean),
           expiring_offline_access_tokens: T.nilable(T::Boolean),
+          httparty_params: T::Hash[Symbol, T.untyped]
         ).void
       end
       def setup(
@@ -68,7 +71,8 @@ module ShopifyAPI
         api_host: nil,
         response_as_struct: false,
         rest_disabled: false,
-        expiring_offline_access_tokens: false
+        expiring_offline_access_tokens: false,
+        httparty_params: {}
       )
         unless ShopifyAPI::AdminVersions::SUPPORTED_ADMIN_VERSIONS.include?(api_version)
           raise Errors::UnsupportedVersionError,
@@ -97,6 +101,7 @@ module ShopifyAPI
         end
 
         load_rest_resources(api_version: api_version)
+        @httparty_params = httparty_params
       end
 
       sig { params(api_version: String).void }
@@ -154,6 +159,9 @@ module ShopifyAPI
 
       sig { returns(T::Boolean) }
       attr_reader :expiring_offline_access_tokens
+
+      sig { returns(T::Hash[Symbol, T.untyped]) }
+      attr_reader :httparty_params
 
       sig { returns(T::Boolean) }
       def embedded?

--- a/lib/shopify_api/context.rb
+++ b/lib/shopify_api/context.rb
@@ -51,7 +51,7 @@ module ShopifyAPI
           response_as_struct: T.nilable(T::Boolean),
           rest_disabled: T.nilable(T::Boolean),
           expiring_offline_access_tokens: T.nilable(T::Boolean),
-          httparty_params: T::Hash[Symbol, T.untyped]
+          httparty_params: T.nilable(T::Hash[Symbol, T.untyped])
         ).void
       end
       def setup(
@@ -72,7 +72,7 @@ module ShopifyAPI
         response_as_struct: false,
         rest_disabled: false,
         expiring_offline_access_tokens: false,
-        httparty_params: {}
+        httparty_params: nil
       )
         unless ShopifyAPI::AdminVersions::SUPPORTED_ADMIN_VERSIONS.include?(api_version)
           raise Errors::UnsupportedVersionError,
@@ -101,7 +101,7 @@ module ShopifyAPI
         end
 
         load_rest_resources(api_version: api_version)
-        @httparty_params = httparty_params
+        @httparty_params = httparty_params || {}
       end
 
       sig { params(api_version: String).void }

--- a/test/context_test.rb
+++ b/test/context_test.rb
@@ -46,6 +46,7 @@ module ShopifyAPITest
       assert_equal("http", ShopifyAPI::Context.host_scheme)
       assert_equal("localhost", ShopifyAPI::Context.host_name)
       assert_equal("example.com", ShopifyAPI::Context.api_host)
+      assert_equal({}, ShopifyAPI::Context.httparty_params)
 
       ShopifyAPI::Context.setup(
         api_key: "key",
@@ -144,6 +145,49 @@ module ShopifyAPITest
       assert_equal("https://tunnel-o-security.com", ShopifyAPI::Context.host)
       assert_equal("tunnel-o-security.com", ShopifyAPI::Context.host_name)
       ENV["HOST"] = old_host
+    end
+
+    def test_with_httparty_params
+      clear_context
+
+      ShopifyAPI::Context.setup(
+        api_key: "key",
+        api_secret_key: "secret",
+        api_version: "2023-10",
+        scope: ["scope1", "scope2"],
+        is_private: true,
+        is_embedded: true,
+        log_level: :off,
+        private_shop: "privateshop.myshopify.com",
+        user_agent_prefix: "user_agent_prefix1",
+        old_api_secret_key: "old_secret",
+        api_host: "example.com",
+        httparty_params: {
+          timeout: 10,
+          open_timeout: 20,
+          read_timeout: 30,
+          write_timeout: 40,
+          debug_output: true,
+          http_proxyaddr: "my.proxy.server",
+          http_proxyport: 8000,
+          http_proxyuser: "user",
+          http_proxypass: "pass",
+        },
+      )
+      assert_equal(
+        {
+          timeout: 10,
+          open_timeout: 20,
+          read_timeout: 30,
+          write_timeout: 40,
+          debug_output: true,
+          http_proxyaddr: "my.proxy.server",
+          http_proxyport: 8000,
+          http_proxyuser: "user",
+          http_proxypass: "pass",
+        },
+        ShopifyAPI::Context.httparty_params,
+      )
     end
 
     def test_send_a_warning_if_log_level_is_invalid

--- a/test/context_test.rb
+++ b/test/context_test.rb
@@ -190,6 +190,26 @@ module ShopifyAPITest
       )
     end
 
+    def test_with_nil_httparty_params_defaults_to_empty_hash
+      clear_context
+
+      ShopifyAPI::Context.setup(
+        api_key: "key",
+        api_secret_key: "secret",
+        api_version: "2023-10",
+        scope: ["scope1", "scope2"],
+        is_private: true,
+        is_embedded: true,
+        log_level: :off,
+        private_shop: "privateshop.myshopify.com",
+        user_agent_prefix: "user_agent_prefix1",
+        old_api_secret_key: "old_secret",
+        api_host: "example.com",
+        httparty_params: nil,
+      )
+      assert_equal({}, ShopifyAPI::Context.httparty_params)
+    end
+
     def test_send_a_warning_if_log_level_is_invalid
       ShopifyAPI::Context.stubs(:log_level).returns(:warn)
       ShopifyAPI::Logger.expects(:warn).with("not_a_level is not a valid log_level. "\


### PR DESCRIPTION
## Description

Fixes #1375

Adds the ability to configure a proxy server for all `ShopifyAPI` HTTP requests

```ruby
ShopifyAPI::Context.setup(
  # other params...
  httparty_params: {
    timeout: 60, # Set the open/read/write timeout for HTTP requests
    open_timeout: 60, # Set the open timeout for HTTP requests
    read_timeout: 60, # Set the read timeout for HTTP requests
    write_timeout: 60, # Set the write timeout for HTTP requests
    debug_output: false, # Set to true to enable debug output for HTTP requests
    http_proxyaddr: "http://proxy.example.com:8080", # Set the HTTP proxy address
    http_proxyport: 8080, # Set the HTTP proxy port
    http_proxyuser: "username", # Set the HTTP proxy username
    http_proxypass: "password", # Set the HTTP proxy password
  }
)
```

## How has this been tested?

proxy server configuration can't be tested via `WebMock` because it ignores proxy settings

## Checklist:

- [x] My commit message follows the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the project documentation.
- [x] I have added a changelog line.
