### PR TITLE
Update oauth logic to account for new admin-web url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Note: For changes to the API, see https://shopify.dev/changelog?filter=api
 ## Unreleased
+- [#1395](https://github.com/Shopify/shopify-api-ruby/pull/1395) use correct internal admin host for 1P app development
 
 ## 14.11.0
 - [#1386](https://github.com/Shopify/shopify-api-ruby/pull/1386) Add support for 2025-07 API version

--- a/lib/shopify_api/auth/oauth.rb
+++ b/lib/shopify_api/auth/oauth.rb
@@ -114,8 +114,9 @@ module ShopifyAPI
           return "https://#{shop}/admin" unless defined?(DevServer) && shop.include?(".my.shop.dev")
 
           # For first-party apps in development only, we leverage DevServer to build the admin base URI
-          admin_web = T.unsafe(Object.const_get("DevServer")).new("web") # rubocop:disable Sorbet/ConstantsFromStrings
-          admin_host = admin_web.host!(nonstandard_host_prefix: "admin")
+          admin_web = T.unsafe(Object.const_get("DevServer")) # rubocop:disable Sorbet/ConstantsFromStrings
+            .new("admin-web")
+          admin_host = admin_web.host!
           shop_name = shop.split(".").first
 
           "https://#{admin_host}/store/#{shop_name}"

--- a/lib/shopify_api/auth/oauth.rb
+++ b/lib/shopify_api/auth/oauth.rb
@@ -116,7 +116,7 @@ module ShopifyAPI
           # For first-party apps in development only, we leverage DevServer to build the admin base URI
           admin_web = T.unsafe(Object.const_get("DevServer")) # rubocop:disable Sorbet/ConstantsFromStrings
             .new("admin-web")
-          admin_host = admin_web.host!
+          admin_host = admin_web.host!(nonstandard_host_prefix: "admin")
           shop_name = shop.split(".").first
 
           "https://#{admin_host}/store/#{shop_name}"


### PR DESCRIPTION
## Description

When using DevServer, it can't find the admin url correctly

This PR fixes that

## How has this been tested?


## Checklist:

- [ ] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [ ] I have performed a self-review of my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the project documentation.
- [ ] I have added a changelog line.
